### PR TITLE
Porting of http1 with scoped API and waitForDataAsync

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,6 +1,7 @@
 name "http"
 description "HTTP server and client implementation and higher level HTTP functionality"
 dependency "vibe-d:crypto" version="*"
+dependency "vibe-d:tls" version="*"
 dependency "vibe-d:inet" version="*"
 dependency "vibe-d:stream" version="*"
 dependency "vibe-d:textfilter" version="*"

--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -1,0 +1,935 @@
+/**
+	Common classes for HTTP clients and servers.
+
+	Copyright: © 2012-2015 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Sönke Ludwig, Jan Krüger
+*/
+module vibe.http.common;
+
+public import vibe.http.status;
+
+import vibe.core.log;
+import vibe.core.net;
+import vibe.inet.message;
+import vibe.stream.operations;
+import vibe.textfilter.urlencode : urlEncode, urlDecode;
+import vibe.utils.array;
+import vibe.internal.freelistref;
+import vibe.internal.interfaceproxy : InterfaceProxy, interfaceProxy;
+import vibe.internal.allocator;
+import vibe.utils.string;
+
+import std.algorithm;
+import std.array;
+import std.conv;
+import std.datetime;
+import std.exception;
+import std.format;
+import std.range : isOutputRange;
+import std.string;
+import std.typecons;
+
+
+enum HTTPVersion {
+	HTTP_1_0,
+	HTTP_1_1
+}
+
+
+enum HTTPMethod {
+	// HTTP standard, RFC 2616
+	GET,
+	HEAD,
+	PUT,
+	POST,
+	PATCH,
+	DELETE,
+	OPTIONS,
+	TRACE,
+	CONNECT,
+
+	// WEBDAV extensions, RFC 2518
+	PROPFIND,
+	PROPPATCH,
+	MKCOL,
+	COPY,
+	MOVE,
+	LOCK,
+	UNLOCK,
+
+	// Versioning Extensions to WebDAV, RFC 3253
+	VERSIONCONTROL,
+	REPORT,
+	CHECKOUT,
+	CHECKIN,
+	UNCHECKOUT,
+	MKWORKSPACE,
+	UPDATE,
+	LABEL,
+	MERGE,
+	BASELINECONTROL,
+	MKACTIVITY,
+
+	// Ordered Collections Protocol, RFC 3648
+	ORDERPATCH,
+
+	// Access Control Protocol, RFC 3744
+	ACL
+}
+
+
+/**
+	Returns the string representation of the given HttpMethod.
+*/
+string httpMethodString(HTTPMethod m)
+@safe nothrow {
+	switch(m){
+		case HTTPMethod.BASELINECONTROL: return "BASELINE-CONTROL";
+		case HTTPMethod.VERSIONCONTROL: return "VERSION-CONTROL";
+		default:
+			try return to!string(m);
+			catch (Exception e) assert(false, e.msg);
+	}
+}
+
+/**
+	Returns the HttpMethod value matching the given HTTP method string.
+*/
+HTTPMethod httpMethodFromString(string str)
+@safe {
+	switch(str){
+		default: throw new Exception("Invalid HTTP method: "~str);
+		// HTTP standard, RFC 2616
+		case "GET": return HTTPMethod.GET;
+		case "HEAD": return HTTPMethod.HEAD;
+		case "PUT": return HTTPMethod.PUT;
+		case "POST": return HTTPMethod.POST;
+		case "PATCH": return HTTPMethod.PATCH;
+		case "DELETE": return HTTPMethod.DELETE;
+		case "OPTIONS": return HTTPMethod.OPTIONS;
+		case "TRACE": return HTTPMethod.TRACE;
+		case "CONNECT": return HTTPMethod.CONNECT;
+
+		// WEBDAV extensions, RFC 2518
+		case "PROPFIND": return HTTPMethod.PROPFIND;
+		case "PROPPATCH": return HTTPMethod.PROPPATCH;
+		case "MKCOL": return HTTPMethod.MKCOL;
+		case "COPY": return HTTPMethod.COPY;
+		case "MOVE": return HTTPMethod.MOVE;
+		case "LOCK": return HTTPMethod.LOCK;
+		case "UNLOCK": return HTTPMethod.UNLOCK;
+
+		// Versioning Extensions to WebDAV, RFC 3253
+		case "VERSION-CONTROL": return HTTPMethod.VERSIONCONTROL;
+		case "REPORT": return HTTPMethod.REPORT;
+		case "CHECKOUT": return HTTPMethod.CHECKOUT;
+		case "CHECKIN": return HTTPMethod.CHECKIN;
+		case "UNCHECKOUT": return HTTPMethod.UNCHECKOUT;
+		case "MKWORKSPACE": return HTTPMethod.MKWORKSPACE;
+		case "UPDATE": return HTTPMethod.UPDATE;
+		case "LABEL": return HTTPMethod.LABEL;
+		case "MERGE": return HTTPMethod.MERGE;
+		case "BASELINE-CONTROL": return HTTPMethod.BASELINECONTROL;
+		case "MKACTIVITY": return HTTPMethod.MKACTIVITY;
+
+		// Ordered Collections Protocol, RFC 3648
+		case "ORDERPATCH": return HTTPMethod.ORDERPATCH;
+
+		// Access Control Protocol, RFC 3744
+		case "ACL": return HTTPMethod.ACL;
+	}
+}
+
+unittest
+{
+	assert(httpMethodString(HTTPMethod.GET) == "GET");
+	assert(httpMethodString(HTTPMethod.UNLOCK) == "UNLOCK");
+	assert(httpMethodString(HTTPMethod.VERSIONCONTROL) == "VERSION-CONTROL");
+	assert(httpMethodString(HTTPMethod.BASELINECONTROL) == "BASELINE-CONTROL");
+	assert(httpMethodFromString("GET") == HTTPMethod.GET);
+	assert(httpMethodFromString("UNLOCK") == HTTPMethod.UNLOCK);
+	assert(httpMethodFromString("VERSION-CONTROL") == HTTPMethod.VERSIONCONTROL);
+}
+
+
+/**
+	Utility function that throws a HTTPStatusException if the _condition is not met.
+*/
+T enforceHTTP(T)(T condition, HTTPStatus statusCode, lazy string message = null, string file = __FILE__, typeof(__LINE__) line = __LINE__)
+{
+	return enforce(condition, new HTTPStatusException(statusCode, message, file, line));
+}
+
+/**
+	Utility function that throws a HTTPStatusException with status code "400 Bad Request" if the _condition is not met.
+*/
+T enforceBadRequest(T)(T condition, lazy string message = null, string file = __FILE__, typeof(__LINE__) line = __LINE__)
+{
+	return enforceHTTP(condition, HTTPStatus.badRequest, message, file, line);
+}
+
+
+/**
+	Represents an HTTP request made to a server.
+*/
+class HTTPRequest {
+	@safe:
+
+	protected {
+		InterfaceProxy!Stream m_conn;
+	}
+
+	public {
+		/// The HTTP protocol version used for the request
+		HTTPVersion httpVersion = HTTPVersion.HTTP_1_1;
+
+		/// The HTTP _method of the request
+		HTTPMethod method = HTTPMethod.GET;
+
+		/** The request URI
+
+			Note that the request URI usually does not include the global
+			'http://server' part, but only the local path and a query string.
+			A possible exception is a proxy server, which will get full URLs.
+		*/
+		string requestURI = "/";
+
+		/// Compatibility alias - scheduled for deprecation
+		alias requestURL = requestURI;
+
+		/// All request _headers
+		InetHeaderMap headers;
+	}
+
+	protected this(InterfaceProxy!Stream conn)
+	{
+		m_conn = conn;
+	}
+
+	protected this()
+	{
+	}
+
+	public override string toString()
+	{
+		return httpMethodString(method) ~ " " ~ requestURL ~ " " ~ getHTTPVersionString(httpVersion);
+	}
+
+	/** Shortcut to the 'Host' header (always present for HTTP 1.1)
+	*/
+	@property string host() const { auto ph = "Host" in headers; return ph ? *ph : null; }
+	/// ditto
+	@property void host(string v) { headers["Host"] = v; }
+
+	/** Returns the mime type part of the 'Content-Type' header.
+
+		This function gets the pure mime type (e.g. "text/plain")
+		without any supplimentary parameters such as "charset=...".
+		Use contentTypeParameters to get any parameter string or
+		headers["Content-Type"] to get the raw value.
+	*/
+	@property string contentType()
+	const {
+		auto pv = "Content-Type" in headers;
+		if( !pv ) return null;
+		auto idx = std.string.indexOf(*pv, ';');
+		return idx >= 0 ? (*pv)[0 .. idx] : *pv;
+	}
+	/// ditto
+	@property void contentType(string ct) { headers["Content-Type"] = ct; }
+
+	/** Returns any supplementary parameters of the 'Content-Type' header.
+
+		This is a semicolon separated ist of key/value pairs. Usually, if set,
+		this contains the character set used for text based content types.
+	*/
+	@property string contentTypeParameters()
+	const {
+		auto pv = "Content-Type" in headers;
+		if( !pv ) return null;
+		auto idx = std.string.indexOf(*pv, ';');
+		return idx >= 0 ? (*pv)[idx+1 .. $] : null;
+	}
+
+	/** Determines if the connection persists across requests.
+	*/
+	@property bool persistent() const
+	{
+		auto ph = "connection" in headers;
+		switch(httpVersion) {
+			case HTTPVersion.HTTP_1_0:
+				if (ph && toLower(*ph) == "keep-alive") return true;
+				return false;
+			case HTTPVersion.HTTP_1_1:
+				if (ph && toLower(*ph) != "keep-alive") return false;
+				return true;
+			default:
+				return false;
+		}
+	}
+}
+
+
+/**
+	Represents the HTTP response from the server back to the client.
+*/
+class HTTPResponse {
+	@safe:
+
+	public {
+		/// The protocol version of the response - should not be changed
+		HTTPVersion httpVersion = HTTPVersion.HTTP_1_1;
+
+		/// The status code of the response, 200 by default
+		int statusCode = HTTPStatus.OK;
+
+		/** The status phrase of the response
+
+			If no phrase is set, a default one corresponding to the status code will be used.
+		*/
+		string statusPhrase;
+
+		/// The response header fields
+		InetHeaderMap headers;
+
+		/// All cookies that shall be set on the client for this request
+		Cookie[string] cookies;
+	}
+
+	public override string toString()
+	{
+		auto app = appender!string();
+		formattedWrite(app, "%s %d %s", getHTTPVersionString(this.httpVersion), this.statusCode, this.statusPhrase);
+		return app.data;
+	}
+
+	/** Shortcut to the "Content-Type" header
+	*/
+	@property string contentType() const { auto pct = "Content-Type" in headers; return pct ? *pct : "application/octet-stream"; }
+	/// ditto
+	@property void contentType(string ct) { headers["Content-Type"] = ct; }
+}
+
+
+/**
+	Respresents a HTTP response status.
+
+	Throwing this exception from within a request handler will produce a matching error page.
+*/
+class HTTPStatusException : Exception {
+	@safe:
+
+	private {
+		int m_status;
+	}
+
+	this(int status, string message = null, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+	{
+		super(message != "" ? message : httpStatusText(status), file, line, next);
+		m_status = status;
+	}
+
+	/// The HTTP status code
+	@property int status() const { return m_status; }
+
+	string debugMessage;
+}
+
+
+final class MultiPart {
+	string contentType;
+
+	InputStream stream;
+	//JsonValue json;
+	string[string] form;
+}
+
+string getHTTPVersionString(HTTPVersion ver)
+@safe nothrow {
+	final switch(ver){
+		case HTTPVersion.HTTP_1_0: return "HTTP/1.0";
+		case HTTPVersion.HTTP_1_1: return "HTTP/1.1";
+	}
+}
+
+
+HTTPVersion parseHTTPVersion(ref string str)
+@safe {
+	enforceBadRequest(str.startsWith("HTTP/"));
+	str = str[5 .. $];
+	int majorVersion = parse!int(str);
+	enforceBadRequest(str.startsWith("."));
+	str = str[1 .. $];
+	int minorVersion = parse!int(str);
+
+	enforceBadRequest( majorVersion == 1 && (minorVersion == 0 || minorVersion == 1) );
+	return minorVersion == 0 ? HTTPVersion.HTTP_1_0 : HTTPVersion.HTTP_1_1;
+}
+
+
+/**
+	Takes an input stream that contains data in HTTP chunked format and outputs the raw data.
+*/
+final class ChunkedInputStream : InputStream
+{
+	@safe:
+
+	private {
+		InterfaceProxy!InputStream m_in;
+		ulong m_bytesInCurrentChunk = 0;
+	}
+
+	deprecated("Use createChunkedInputStream() instead.")
+	this(InputStream stream)
+	{
+		this(interfaceProxy!InputStream(stream), true);
+	}
+
+	/// private
+	this(InterfaceProxy!InputStream stream, bool dummy)
+	{
+		assert(!!stream);
+		m_in = stream;
+		readChunk();
+	}
+
+	@property bool empty() const { return m_bytesInCurrentChunk == 0; }
+
+	@property ulong leastSize() const { return m_bytesInCurrentChunk; }
+
+	@property bool dataAvailableForRead() { return m_bytesInCurrentChunk > 0 && m_in.dataAvailableForRead; }
+
+	const(ubyte)[] peek()
+	{
+		auto dt = m_in.peek();
+		return dt[0 .. min(dt.length, m_bytesInCurrentChunk)];
+	}
+
+	size_t read(scope ubyte[] dst, IOMode mode)
+	{
+		enforceBadRequest(!empty, "Read past end of chunked stream.");
+		size_t nbytes = 0;
+
+		while (dst.length > 0) {
+			enforceBadRequest(m_bytesInCurrentChunk > 0, "Reading past end of chunked HTTP stream.");
+
+			auto sz = cast(size_t)min(m_bytesInCurrentChunk, dst.length);
+			m_in.read(dst[0 .. sz]);
+			dst = dst[sz .. $];
+			m_bytesInCurrentChunk -= sz;
+			nbytes += sz;
+
+			// FIXME: this blocks, but shouldn't for IOMode.once/immediat
+			if( m_bytesInCurrentChunk == 0 ){
+				// skip current chunk footer and read next chunk
+				ubyte[2] crlf;
+				m_in.read(crlf);
+				enforceBadRequest(crlf[0] == '\r' && crlf[1] == '\n');
+				readChunk();
+			}
+
+			if (mode != IOMode.all) break;
+		}
+
+		return nbytes;
+	}
+
+	alias read = InputStream.read;
+
+	private void readChunk()
+	{
+		assert(m_bytesInCurrentChunk == 0);
+		// read chunk header
+		logTrace("read next chunk header");
+		auto ln = () @trusted { return cast(string)m_in.readLine(); } ();
+		logTrace("got chunk header: %s", ln);
+		m_bytesInCurrentChunk = parse!ulong(ln, 16u);
+
+		if( m_bytesInCurrentChunk == 0 ){
+			// empty chunk denotes the end
+			// skip final chunk footer
+			ubyte[2] crlf;
+			m_in.read(crlf);
+			enforceBadRequest(crlf[0] == '\r' && crlf[1] == '\n');
+		}
+	}
+}
+
+/// Creates a new `ChunkedInputStream` instance.
+ChunkedInputStream chunkedInputStream(IS)(IS source_stream) if (isInputStream!IS)
+{
+	return new ChunkedInputStream(interfaceProxy!InputStream(source_stream), true);
+}
+
+/// Creates a new `ChunkedInputStream` instance.
+FreeListRef!ChunkedInputStream createChunkedInputStreamFL(IS)(IS source_stream) if (isInputStream!IS)
+{
+	return () @trusted { return FreeListRef!ChunkedInputStream(interfaceProxy!InputStream(source_stream), true); } ();
+}
+
+
+/**
+	Outputs data to an output stream in HTTP chunked format.
+*/
+final class ChunkedOutputStream : OutputStream {
+	@safe:
+
+	alias ChunkExtensionCallback = string delegate(in ubyte[] data);
+	private {
+		InterfaceProxy!OutputStream m_out;
+		AllocAppender!(ubyte[]) m_buffer;
+		size_t m_maxBufferSize = 4*1024;
+		bool m_finalized = false;
+		ChunkExtensionCallback m_chunkExtensionCallback = null;
+	}
+
+	deprecated("Use createChunkedOutputStream() instead.")
+	this(OutputStream stream, IAllocator alloc = vibeThreadAllocator())
+	{
+		this(interfaceProxy!OutputStream(stream), alloc, true);
+	}
+
+	/// private
+	this(InterfaceProxy!OutputStream stream, IAllocator alloc, bool dummy)
+	{
+		m_out = stream;
+        m_buffer = AllocAppender!(ubyte[])(alloc);
+	}
+
+	/** Maximum buffer size used to buffer individual chunks.
+
+		A size of zero means unlimited buffer size. Explicit flush is required
+		in this case to empty the buffer.
+	*/
+	@property size_t maxBufferSize() const { return m_maxBufferSize; }
+	/// ditto
+	@property void maxBufferSize(size_t bytes) { m_maxBufferSize = bytes; if (m_buffer.data.length >= m_maxBufferSize) flush(); }
+
+	/** A delegate used to specify the extensions for each chunk written to the underlying stream.
+
+	 	The delegate has to be of type `string delegate(in const(ubyte)[] data)` and gets handed the
+	 	data of each chunk before it is written to the underlying stream. If it's return value is non-empty,
+	 	it will be added to the chunk's header line.
+
+	 	The returned chunk extension string should be of the format `key1=value1;key2=value2;[...];keyN=valueN`
+	 	and **not contain any carriage return or newline characters**.
+
+	 	Also note that the delegate should accept the passed data through a scoped argument. Thus, **no references
+	 	to the provided data should be stored in the delegate**. If the data has to be stored for later use,
+	 	it needs to be copied first.
+	 */
+	@property ChunkExtensionCallback chunkExtensionCallback() const { return m_chunkExtensionCallback; }
+	/// ditto
+	@property void chunkExtensionCallback(ChunkExtensionCallback cb) { m_chunkExtensionCallback = cb; }
+
+	private void append(scope void delegate(scope ubyte[] dst) @safe del, size_t nbytes)
+	{
+		assert(del !is null);
+		auto sz = nbytes;
+		if (m_maxBufferSize > 0 && m_maxBufferSize < m_buffer.data.length + sz)
+			sz = m_maxBufferSize - min(m_buffer.data.length, m_maxBufferSize);
+
+		if (sz > 0)
+		{
+			m_buffer.reserve(sz);
+			() @trusted {
+				m_buffer.append((scope ubyte[] dst) {
+					debug assert(dst.length >= sz);
+					del(dst[0..sz]);
+					return sz;
+				});
+			} ();
+		}
+	}
+
+	size_t write(in ubyte[] bytes_, IOMode mode)
+	{
+		assert(!m_finalized);
+		const(ubyte)[] bytes = bytes_;
+		size_t nbytes = 0;
+		while (bytes.length > 0) {
+			append((scope ubyte[] dst) {
+					auto n = dst.length;
+					dst[] = bytes[0..n];
+					bytes = bytes[n..$];
+					nbytes += n;
+				}, bytes.length);
+			if (mode == IOMode.immediate) break;
+			if (mode == IOMode.once && nbytes > 0) break;
+			if (bytes.length > 0)
+				flush();
+		}
+		return nbytes;
+	}
+
+	alias write = OutputStream.write;
+
+	void flush()
+	{
+		assert(!m_finalized);
+		auto data = m_buffer.data();
+		if( data.length ){
+			writeChunk(data);
+		}
+		m_out.flush();
+		() @trusted { m_buffer.reset(AppenderResetMode.reuseData); } ();
+	}
+
+	void finalize()
+	{
+		if (m_finalized) return;
+		flush();
+		() @trusted { m_buffer.reset(AppenderResetMode.freeData); } ();
+		m_finalized = true;
+		writeChunk([]);
+		m_out.flush();
+	}
+
+	private void writeChunk(in ubyte[] data)
+	{
+		import vibe.stream.wrapper;
+		auto rng = streamOutputRange(m_out);
+		formattedWrite(() @trusted { return &rng; } (), "%x", data.length);
+		if (m_chunkExtensionCallback !is null)
+		{
+			rng.put(';');
+			auto extension = m_chunkExtensionCallback(data);
+			assert(!extension.startsWith(';'));
+			debug assert(extension.indexOf('\r') < 0);
+			debug assert(extension.indexOf('\n') < 0);
+			rng.put(extension);
+		}
+		rng.put("\r\n");
+		rng.put(data);
+		rng.put("\r\n");
+	}
+}
+
+/// Creates a new `ChunkedInputStream` instance.
+ChunkedOutputStream createChunkedOutputStream(OS)(OS destination_stream, IAllocator allocator = vibeThreadAllocator()) if (isOutputStream!OS)
+{
+	return new ChunkedOutputStream(interfaceProxy!OutputStream(destination_stream), allocator, true);
+}
+
+/// Creates a new `ChunkedOutputStream` instance.
+FreeListRef!ChunkedOutputStream createChunkedOutputStreamFL(OS)(OS destination_stream, IAllocator allocator = vibeThreadAllocator()) if (isOutputStream!OS)
+{
+	return FreeListRef!ChunkedOutputStream(interfaceProxy!OutputStream(destination_stream), allocator, true);
+}
+
+
+final class Cookie {
+	@safe:
+
+	private {
+		string m_value;
+		string m_domain;
+		string m_path;
+		string m_expires;
+		long m_maxAge;
+		bool m_secure;
+		bool m_httpOnly;
+	}
+
+	enum Encoding {
+		url,
+		raw,
+		none = raw
+	}
+
+	/// Cookie payload
+	@property void value(string value) { m_value = urlEncode(value); }
+	/// ditto
+	@property string value() const { return urlDecode(m_value); }
+
+	/// Undecoded cookie payload
+	@property void rawValue(string value) { m_value = value; }
+	/// ditto
+	@property string rawValue() const { return m_value; }
+
+	/// The domain for which the cookie is valid
+	@property void domain(string value) { m_domain = value; }
+	/// ditto
+	@property string domain() const { return m_domain; }
+
+	/// The path/local URI for which the cookie is valid
+	@property void path(string value) { m_path = value; }
+	/// ditto
+	@property string path() const { return m_path; }
+
+	/// Expiration date of the cookie
+	@property void expires(string value) { m_expires = value; }
+	/// ditto
+	@property void expires(SysTime value) { m_expires = value.toRFC822DateTimeString(); }
+	/// ditto
+	@property string expires() const { return m_expires; }
+
+	/** Maximum life time of the cookie
+
+		This is the modern variant of `expires`. For backwards compatibility it
+		is recommended to set both properties, or to use the `expire` method.
+	*/
+	@property void maxAge(long value) { m_maxAge = value; }
+	/// ditto
+	@property void maxAge(Duration value) { m_maxAge = value.total!"seconds"; }
+	/// ditto
+	@property long maxAge() const { return m_maxAge; }
+
+	/** Require a secure connection for transmission of this cookie
+	*/
+	@property void secure(bool value) { m_secure = value; }
+	/// ditto
+	@property bool secure() const { return m_secure; }
+
+	/** Prevents access to the cookie from scripts.
+	*/
+	@property void httpOnly(bool value) { m_httpOnly = value; }
+	/// ditto
+	@property bool httpOnly() const { return m_httpOnly; }
+
+	/** Sets the "expires" and "max-age" attributes to limit the life time of
+		the cookie.
+	*/
+	void expire(Duration max_age)
+	{
+		this.expires = Clock.currTime(UTC()) + max_age;
+		this.maxAge = max_age;
+	}
+	/// ditto
+	void expire(SysTime expire_time)
+	{
+		this.expires = expire_time;
+		this.maxAge = expire_time - Clock.currTime(UTC());
+	}
+
+	/// Sets the cookie value encoded with the specified encoding.
+	void setValue(string value, Encoding encoding)
+	{
+		final switch (encoding) {
+			case Encoding.url: m_value = urlEncode(value); break;
+			case Encoding.none: validateValue(value); m_value = value; break;
+		}
+	}
+
+	/// Writes out the full cookie in HTTP compatible format.
+	void writeString(R)(R dst, string name)
+		if (isOutputRange!(R, char))
+	{
+		import vibe.textfilter.urlencode;
+		dst.put(name);
+		dst.put('=');
+		validateValue(this.value);
+		dst.put(this.value);
+		if (this.domain && this.domain != "") {
+			dst.put("; Domain=");
+			dst.put(this.domain);
+		}
+		if (this.path != "") {
+			dst.put("; Path=");
+			dst.put(this.path);
+		}
+		if (this.expires != "") {
+			dst.put("; Expires=");
+			dst.put(this.expires);
+		}
+		if (this.maxAge) dst.formattedWrite("; Max-Age=%s", this.maxAge);
+		if (this.secure) dst.put("; Secure");
+		if (this.httpOnly) dst.put("; HttpOnly");
+	}
+
+	private static void validateValue(string value)
+	{
+		enforce(!value.canFind(';') && !value.canFind('"'));
+	}
+}
+
+unittest {
+	import std.exception : assertThrown;
+
+	auto c = new Cookie;
+	c.value = "foo";
+	assert(c.value == "foo");
+	assert(c.rawValue == "foo");
+
+	c.value = "foo$";
+	assert(c.value == "foo$");
+	assert(c.rawValue == "foo%24", c.rawValue);
+
+	c.value = "foo&bar=baz?";
+	assert(c.value == "foo&bar=baz?");
+	assert(c.rawValue == "foo%26bar%3Dbaz%3F", c.rawValue);
+
+	c.setValue("foo%", Cookie.Encoding.raw);
+	assert(c.rawValue == "foo%");
+	assertThrown(c.value);
+
+	assertThrown(c.setValue("foo;bar", Cookie.Encoding.raw));
+}
+
+
+/**
+*/
+struct CookieValueMap {
+	@safe:
+
+	struct Cookie {
+		/// Name of the cookie
+		string name;
+
+		/// The raw cookie value as transferred over the wire
+		string rawValue;
+
+		this(string name, string value, .Cookie.Encoding encoding = .Cookie.Encoding.url)
+		{
+			this.name = name;
+			this.setValue(value, encoding);
+		}
+
+		/// Treats the value as URL encoded
+		string value() const { return urlDecode(rawValue); }
+		/// ditto
+		void value(string val) { rawValue = urlEncode(val); }
+
+		/// Sets the cookie value, applying the specified encoding.
+		void setValue(string value, .Cookie.Encoding encoding = .Cookie.Encoding.url)
+		{
+			final switch (encoding) {
+				case .Cookie.Encoding.none: this.rawValue = value; break;
+				case .Cookie.Encoding.url: this.rawValue = urlEncode(value); break;
+			}
+		}
+	}
+
+	private {
+		Cookie[] m_entries;
+	}
+
+	auto length(){
+		return m_entries.length;
+	}
+
+	string get(string name, string def_value = null)
+	const {
+		foreach (ref c; m_entries)
+			if (c.name == name)
+				return c.value;
+		return def_value;
+	}
+
+	string[] getAll(string name)
+	const {
+		string[] ret;
+		foreach(c; m_entries)
+			if( c.name == name )
+				ret ~= c.value;
+		return ret;
+	}
+
+	void add(string name, string value, .Cookie.Encoding encoding = .Cookie.Encoding.url){
+		m_entries ~= Cookie(name, value, encoding);
+	}
+
+	void opIndexAssign(string value, string name)
+	{
+		m_entries ~= Cookie(name, value);
+	}
+
+	string opIndex(string name)
+	const {
+		import core.exception : RangeError;
+		foreach (ref c; m_entries)
+			if (c.name == name)
+				return c.value;
+		throw new RangeError("Non-existent cookie: "~name);
+	}
+
+	int opApply(scope int delegate(ref Cookie) @safe del)
+	{
+		foreach(ref c; m_entries)
+			if( auto ret = del(c) )
+				return ret;
+		return 0;
+	}
+
+	int opApply(scope int delegate(ref Cookie) @safe del)
+	const {
+		foreach(Cookie c; m_entries)
+			if( auto ret = del(c) )
+				return ret;
+		return 0;
+	}
+
+	int opApply(scope int delegate(string name, string value) @safe del)
+	{
+		foreach(ref c; m_entries)
+			if( auto ret = del(c.name, c.value) )
+				return ret;
+		return 0;
+	}
+
+	int opApply(scope int delegate(string name, string value) @safe del)
+	const {
+		foreach(Cookie c; m_entries)
+			if( auto ret = del(c.name, c.value) )
+				return ret;
+		return 0;
+	}
+
+	auto opBinaryRight(string op)(string name) if(op == "in")
+	{
+		return Ptr(&this, name);
+	}
+
+	auto opBinaryRight(string op)(string name) const if(op == "in")
+	{
+		return const(Ptr)(&this, name);
+	}
+
+	private static struct Ref {
+		private {
+			CookieValueMap* map;
+			string name;
+		}
+
+		@property string get() const { return (*map)[name]; }
+		void opAssign(string newval) {
+			foreach (ref c; *map)
+				if (c.name == name) {
+					c.value = newval;
+					return;
+				}
+			assert(false);
+		}
+		alias get this;
+	}
+	private static struct Ptr {
+		private {
+			CookieValueMap* map;
+			string name;
+		}
+		bool opCast() const {
+			foreach (ref c; map.m_entries)
+				if (c.name == name)
+					return true;
+			return false;
+		}
+		inout(Ref) opUnary(string op : "*")() inout { return inout(Ref)(map, name); }
+	}
+}
+
+unittest {
+	CookieValueMap m;
+	m["foo"] = "bar;baz%1";
+	assert(m["foo"] == "bar;baz%1");
+
+	m["foo"] = "bar";
+	assert(m.getAll("foo") == ["bar;baz%1", "bar"]);
+
+	assert("foo" in m);
+	if (auto val = "foo" in m) {
+		assert(*val == "bar;baz%1");
+	} else assert(false);
+	*("foo" in m) = "baz";
+	assert(m["foo"] == "baz");
+}

--- a/source/vibe/http/internal/http1.d
+++ b/source/vibe/http/internal/http1.d
@@ -1,11 +1,402 @@
 module vibe.http.internal.http1;
 
 import vibe.core.stream;
+import vibe.core.core : runTask;
+import vibe.core.net;
+import vibe.http.server;
+import vibe.internal.allocator;
+import vibe.internal.freelistref;
+import vibe.internal.interfaceproxy : InterfaceProxy;
+import vibe.core.file;
+import vibe.core.log;
+import vibe.inet.url;
+import vibe.inet.webform;
+import vibe.data.json;
+import vibe.stream.wrapper : ConnectionProxyStream, createConnectionProxyStream, createConnectionProxyStreamFL;
+import vibe.utils.array;
+import vibe.utils.string;
+import vibe.stream.counting;
+import vibe.stream.operations;
+import vibe.stream.zlib;
+import vibe.textfilter.urlencode : urlEncode, urlDecode;
+import vibe.stream.tls;
 
+import std.datetime;
+import std.typecons;
+import std.conv;
+import std.array;
+import std.algorithm;
+import std.format;
+import std.parallelism;
+import std.exception;
+import std.string;
+import std.encoding : sanitize;
+import std.traits : isInstanceOf, ReturnType;
 
-private void handleHTTP1Connection(ConnectionStream)(ConnectionStream connection)
-	if (isConnectionStream!ConnectionStream)
+private alias TLSStreamType = ReturnType!(createTLSStreamFL!(InterfaceProxy!Stream)); 
+
+void handleHTTP1Connection(ConnectionStream)(ConnectionStream connection, HTTPServerContext context)
+@safe	if (isConnectionStream!ConnectionStream)
 {
+	connection.tcpNoDelay = true;
 
+	logInfo("Connection");
+    version(HaveNoTLS) {} else {
+        TLSStreamType tls_stream;
+    }
+
+	// If this is a HTTPS server, initiate TLS
+    if (context.tlsContext) {
+        version (HaveNoTLS) assert(false, "No TLS support compiled in.");
+        else {
+            logDebug("Accept TLS connection: %s", context.tlsContext.kind);
+
+            //TODO: determine if there's a better alternative to InterfaceProxy
+            InterfaceProxy!Stream http_stream;
+            http_stream = connection;
+
+            // TODO: reverse DNS lookup for peer_name of the incoming connection for TLS client certificate verification purposes
+            tls_stream = createTLSStreamFL(http_stream, context.tlsContext, TLSStreamState.accepting, null, connection.remoteAddress);
+            http_stream = tls_stream;
+        }
+    }
+	handleHTTP1Request(connection, context);
+}
+
+private void handleHTTP1Request(ConnectionStream)(ConnectionStream connection, HTTPContext context)
+@safe
+{
+	logInfo("Request");
+
+	HTTPServerSettings settings;
+	InterfaceProxy!Stream http_stream;
+	http_stream = connection;
+	bool keep_alive;
+	() @trusted {
+		import vibe.internal.utilallocator: RegionListAllocator;
+		version (VibeManualMemoryManagement)
+			scope request_allocator = new RegionListAllocator!(shared(Mallocator), false)(1024, Mallocator.instance);
+		else
+			scope request_allocator = new RegionListAllocator!(shared(GCAllocator), true)(1024, GCAllocator.instance);
+
+		originalHandleRequest(http_stream, connection, context, settings, keep_alive, request_allocator);
+
+		if (!keep_alive) { connection.close; return; }
+	} ();
+
+	// NOTE: this requires that connection has no scoped destruction
+	// Currently vibe-d/vibe-core mantains the destructor,
+	// which prevents the closure from being built
+	connection.waitForDataAsync( (bool st) @safe {
+			if (!st) connection.close;
+			else runTask(&handleHTTP1Request, connection, context);
+		});
+}
+
+/* Previous vibe.http handleRequest
+ * Gets called by handleHTTP1Request
+ */
+bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_connection, HTTPServerContext listen_info, ref HTTPServerSettings settings, ref bool keep_alive, scope IAllocator request_allocator)
+@safe {
+
+	logInfo ("Old request handler");
+	import std.algorithm.searching : canFind;
+
+	SysTime reqtime = Clock.currTime(UTC());
+
+	// some instances that live only while the request is running
+	//FreeListRef!HTTPServerRequest req = FreeListRef!HTTPServerRequest(reqtime, listen_info.bindPort);
+    auto req = HTTPServerRequest(reqtime, listen_info.bindPort);
+
+	FreeListRef!TimeoutHTTPInputStream timeout_http_input_stream;
+	FreeListRef!LimitedHTTPInputStream limited_http_input_stream;
+	FreeListRef!ChunkedInputStream chunked_input_stream;
+
+	// store the IP address
+	req.clientAddress = tcp_connection.remoteAddress;
+
+	if (!listen_info.hasVirtualHosts) {
+		logWarn("Didn't find a HTTP listening context for incoming connection. Dropping.");
+		keep_alive = false;
+		return false;
+	}
+
+	// Default to the first virtual host for this listener
+	HTTPServerContext.VirtualHost context = listen_info.virtualHosts[0];
+	HTTPServerRequestDelegate request_task = context.requestHandler;
+	settings = context.settings;
+
+	// temporarily set to the default settings, the virtual host specific settings will be set further down
+	req.m_settings = settings;
+
+	// Create the response object
+	InterfaceProxy!ConnectionStream cproxy = tcp_connection;
+	auto res = HTTPServerResponse(http_stream, cproxy, settings, request_allocator/*.Scoped_payload*/);
+    auto istls = listen_info.tlsContext !is null;
+    req.tls = istls;
+    res.tls = istls;
+
+ 	if (req.tls) {
+		version (HaveNoTLS) assert(false);
+		else {
+			static if (is(InterfaceProxy!ConnectionStream == ConnectionStream))
+				req.clientCertificate = (cast(TLSStream)http_stream).peerCertificate;
+			else
+                req.clientCertificate = http_stream.extract!TLSStreamType.peerCertificate;
+				assert(false);
+		}
+	}
+
+	// Error page handler
+	void errorOut(int code, string msg, string debug_msg, Throwable ex)
+	@safe {
+		assert(!res.headerWritten);
+
+		// stack traces sometimes contain random bytes - make sure they are replaced
+		debug_msg = sanitizeUTF8(cast(const(ubyte)[])debug_msg);
+
+		res.setStatusCode(code);
+		if (settings && settings.errorPageHandler) {
+			/*scope*/ auto err = new HTTPServerErrorInfo;
+			err.code = code;
+			err.message = msg;
+			err.debugMessage = debug_msg;
+			err.exception = ex;
+			settings.handleErrorPage(req, res, err);
+		} else {
+			if (debug_msg.length)
+				res.writeBody(format("%s - %s\n\n%s\n\nInternal error information:\n%s", code, httpStatusText(code), msg, debug_msg));
+			else res.writeBody(format("%s - %s\n\n%s", code, httpStatusText(code), msg));
+		}
+		assert(res.headerWritten);
+	}
+
+	bool parsed = false;
+	/*bool*/ keep_alive = false;
+
+	// parse the request
+	try {
+		logTrace("reading request..");
+
+		// limit the total request time
+		InterfaceProxy!InputStream reqReader = http_stream;
+		if (settings.maxRequestTime > dur!"seconds"(0) && settings.maxRequestTime != Duration.max) {
+			timeout_http_input_stream = FreeListRef!TimeoutHTTPInputStream(reqReader, settings.maxRequestTime, reqtime);
+			reqReader = timeout_http_input_stream;
+		}
+
+		// basic request parsing
+		parseRequestHeader(req, reqReader, request_allocator, settings.maxRequestHeaderSize);
+		logTrace("Got request header.");
+
+		// find the matching virtual host
+		string reqhost;
+		ushort reqport = 0;
+		{
+			string s = req.host;
+			enforceHTTP(s.length > 0 || req.httpVersion <= HTTPVersion.HTTP_1_0, HTTPStatus.badRequest, "Missing Host header.");
+			if (s.startsWith('[')) { // IPv6 address
+				auto idx = s.indexOf(']');
+				enforce(idx > 0, "Missing closing ']' for IPv6 address.");
+				reqhost = s[1 .. idx];
+				s = s[idx+1 .. $];
+			} else if (s.length) { // host name or IPv4 address
+				auto idx = s.indexOf(':');
+				if (idx < 0) idx = s.length;
+				enforceHTTP(idx > 0, HTTPStatus.badRequest, "Missing Host header.");
+				reqhost = s[0 .. idx];
+				s = s[idx .. $];
+			}
+			if (s.startsWith(':')) reqport = s[1 .. $].to!ushort;
+		}
+
+		foreach (ctx; listen_info.virtualHosts)
+			if (icmp2(ctx.settings.hostName, reqhost) == 0 &&
+				(!reqport || reqport == ctx.settings.port))
+			{
+				context = ctx;
+				settings = ctx.settings;
+				request_task = ctx.requestHandler;
+				break;
+			}
+		req.m_settings = settings;
+		res.m_settings = settings;
+
+		// setup compressed output
+		if (settings.useCompressionIfPossible) {
+			if (auto pae = "Accept-Encoding" in req.headers) {
+				if (canFind(*pae, "gzip")) {
+					res.headers["Content-Encoding"] = "gzip";
+				} else if (canFind(*pae, "deflate")) {
+					res.headers["Content-Encoding"] = "deflate";
+				}
+			}
+		}
+
+		// limit request size
+		if (auto pcl = "Content-Length" in req.headers) {
+			string v = *pcl;
+			auto contentLength = parse!ulong(v); // DMDBUG: to! thinks there is a H in the string
+			enforceBadRequest(v.length == 0, "Invalid content-length");
+			enforceBadRequest(settings.maxRequestSize <= 0 || contentLength <= settings.maxRequestSize, "Request size too big");
+			limited_http_input_stream = FreeListRef!LimitedHTTPInputStream(reqReader, contentLength);
+		} else if (auto pt = "Transfer-Encoding" in req.headers) {
+			enforceBadRequest(icmp(*pt, "chunked") == 0);
+			chunked_input_stream = createChunkedInputStreamFL(reqReader);
+			InterfaceProxy!InputStream ciproxy = chunked_input_stream;
+			limited_http_input_stream = FreeListRef!LimitedHTTPInputStream(ciproxy, settings.maxRequestSize, true);
+		} else {
+			limited_http_input_stream = FreeListRef!LimitedHTTPInputStream(reqReader, 0);
+		}
+		req.bodyReader = limited_http_input_stream;
+
+		// handle Expect header
+		if (auto pv = "Expect" in req.headers) {
+			if (icmp2(*pv, "100-continue") == 0) {
+				logTrace("sending 100 continue");
+				http_stream.write("HTTP/1.1 100 Continue\r\n\r\n");
+			}
+		}
+
+        // eagerly parse the URL as its lightweight and defacto @nogc
+		auto url = URL.parse(req.requestURI);
+		req.queryString = url.queryString;
+		req.username = url.username;
+		req.password = url.password;
+		req.requestPath = url.path;
+
+		// lookup the session
+		if (settings.sessionStore) {
+			// use the first cookie that contains a valid session ID in case
+			// of multiple matching session cookies
+			foreach (val; req.cookies.getAll(settings.sessionIdCookie)) {
+				req.session = settings.sessionStore.open(val);
+				res.m_session = req.session;
+				if (req.session) break;
+			}
+		}
+
+		// write default headers
+		if (req.method == HTTPMethod.HEAD) res.m_isHeadResponse = true;
+		if (settings.serverString.length)
+			res.headers["Server"] = settings.serverString;
+		res.headers["Date"] = formatRFC822DateAlloc(request_allocator, reqtime);
+		if (req.persistent) res.headers["Keep-Alive"] = formatAlloc(request_allocator, "timeout=%d", settings.keepAliveTimeout.total!"seconds"());
+
+		// finished parsing the request
+		parsed = true;
+		logTrace("persist: %s", req.persistent);
+		keep_alive = req.persistent;
+
+		// handle the request
+		logTrace("handle request (body %d)", req.bodyReader.leastSize);
+		res.httpVersion = req.httpVersion;
+		request_task(req, res);
+
+		// if no one has written anything, return 404
+		if (!res.headerWritten) {
+			string dbg_msg;
+			logDiagnostic("No response written for %s", req.requestURI);
+			if (settings.options & HTTPServerOption.errorStackTraces)
+				dbg_msg = format("No routes match path '%s'", req.requestURI);
+			errorOut(HTTPStatus.notFound, httpStatusText(HTTPStatus.notFound), dbg_msg, null);
+		}
+	} catch (HTTPStatusException err) {
+		if (!res.headerWritten) errorOut(err.status, err.msg, err.debugMessage, err);
+		else logDiagnostic("HTTPSterrorOutatusException while writing the response: %s", err.msg);
+		debug logDebug("Exception while handling request %s %s: %s", req.method, req.requestURI, () @trusted { return err.toString().sanitize; } ());
+		if (!parsed || res.headerWritten || justifiesConnectionClose(err.status))
+			keep_alive = false;
+	} catch (UncaughtException e) {
+		auto status = parsed ? HTTPStatus.internalServerError : HTTPStatus.badRequest;
+		string dbg_msg;
+		if (settings.options & HTTPServerOption.errorStackTraces) dbg_msg = () @trusted { return e.toString().sanitize; } ();
+		if (!res.headerWritten && tcp_connection.connected) errorOut(status, httpStatusText(status), dbg_msg, e);
+		else logDiagnostic("Error while writing the response: %s", e.msg);
+		debug logDebug("Exception while handling request %s %s: %s", req.method, req.requestURI, () @trusted { return e.toString().sanitize(); } ());
+		if (!parsed || res.headerWritten || !cast(Exception)e) keep_alive = false;
+	}
+
+	if (tcp_connection.connected) {
+		if (req.bodyReader && !req.bodyReader.empty) {
+			req.bodyReader.pipe(nullSink);
+			logTrace("dropped body");
+		}
+	}
+
+	// finalize (e.g. for chunked encoding)
+	res.finalize();
+
+	foreach (k, v ; req._files) {
+		if (existsFile(v.tempPath)) {
+			removeFile(v.tempPath);
+			logDebug("Deleted upload tempfile %s", v.tempPath.toString());
+		}
+	}
+
+	if (!req.noLog) {
+		// log the request to access log
+		foreach (log; context.loggers)
+			log.log(req, res);
+	}
+
+	//logTrace("return %s (used pool memory: %s/%s)", keep_alive, request_allocator.allocatedSize, request_allocator.totalSize);
+	logTrace("return %s", keep_alive);
+	return keep_alive != false;
+}
+
+final class LimitedHTTPInputStream : LimitedInputStream {
+@safe:
+
+	this(InterfaceProxy!InputStream stream, ulong byte_limit, bool silent_limit = false) {
+		super(stream, byte_limit, silent_limit, true);
+	}
+	override void onSizeLimitReached() {
+		throw new HTTPStatusException(HTTPStatus.requestEntityTooLarge);
+	}
+}
+
+final class TimeoutHTTPInputStream : InputStream {
+@safe:
+
+	private {
+		long m_timeref;
+		long m_timeleft;
+		InterfaceProxy!InputStream m_in;
+	}
+
+	this(InterfaceProxy!InputStream stream, Duration timeleft, SysTime reftime)
+	{
+		enforce(timeleft > 0.seconds, "Timeout required");
+		m_in = stream;
+		m_timeleft = timeleft.total!"hnsecs"();
+		m_timeref = reftime.stdTime();
+	}
+
+	@property bool empty() { enforce(m_in, "InputStream missing"); return m_in.empty(); }
+	@property ulong leastSize() { enforce(m_in, "InputStream missing"); return m_in.leastSize();  }
+	@property bool dataAvailableForRead() {  enforce(m_in, "InputStream missing"); return m_in.dataAvailableForRead; }
+	const(ubyte)[] peek() { return m_in.peek(); }
+
+	size_t read(scope ubyte[] dst, IOMode mode)
+	{
+		enforce(m_in, "InputStream missing");
+		size_t nread = 0;
+		checkTimeout();
+		// FIXME: this should use ConnectionStream.waitForData to enforce the timeout during the
+		// read operation
+		return m_in.read(dst, mode);
+	}
+
+	alias read = InputStream.read;
+
+	private void checkTimeout()
+	@safe {
+		auto curr = Clock.currStdTime();
+		auto diff = curr - m_timeref;
+		if (diff > m_timeleft) throw new HTTPStatusException(HTTPStatus.RequestTimeout);
+		m_timeleft -= diff;
+		m_timeref = curr;
+	}
 }
 

--- a/source/vibe/http/internal/http1.d
+++ b/source/vibe/http/internal/http1.d
@@ -103,7 +103,7 @@ private void handleHTTP1Request(ConnectionStream)(ConnectionStream connection, H
 /* Previous vibe.http handleRequest
  * Gets called by handleHTTP1Request
  */
-bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_connection, HTTPServerContext listen_info, ref HTTPServerSettings settings, ref bool keep_alive, scope IAllocator request_allocator)
+bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_connection, HTTPServerContext listen_info, HTTPServerSettings settings, ref bool keep_alive, scope IAllocator request_allocator)
 @safe {
 
 	logInfo ("Old request handler");
@@ -163,8 +163,9 @@ bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_
 		debug_msg = sanitizeUTF8(cast(const(ubyte)[])debug_msg);
 
 		res.setStatusCode(code);
-		if (settings && settings.errorPageHandler) {
-			/*scope*/ auto err = new HTTPServerErrorInfo;
+		if (settings.errorPageHandler) {
+			//[>scope<] auto err = new HTTPServerErrorInfo;
+            HTTPServerErrorInfo err;
 			err.code = code;
 			err.message = msg;
 			err.debugMessage = debug_msg;

--- a/source/vibe/http/internal/http1.d
+++ b/source/vibe/http/internal/http1.d
@@ -41,25 +41,25 @@ void handleHTTP1Connection(ConnectionStream)(ConnectionStream connection, HTTPSe
 	connection.tcpNoDelay = true;
 
 	logInfo("Connection");
-    version(HaveNoTLS) {} else {
-        TLSStreamType tls_stream;
-    }
+	version(HaveNoTLS) {} else {
+		TLSStreamType tls_stream;
+	}
 
 	// If this is a HTTPS server, initiate TLS
-    if (context.tlsContext) {
-        version (HaveNoTLS) assert(false, "No TLS support compiled in.");
-        else {
-            logDebug("Accept TLS connection: %s", context.tlsContext.kind);
+	if (context.tlsContext) {
+		version (HaveNoTLS) assert(false, "No TLS support compiled in.");
+		else {
+			logDebug("Accept TLS connection: %s", context.tlsContext.kind);
 
-            //TODO: determine if there's a better alternative to InterfaceProxy
-            InterfaceProxy!Stream http_stream;
-            http_stream = connection;
+			//TODO: determine if there's a better alternative to InterfaceProxy
+			InterfaceProxy!Stream http_stream;
+			http_stream = connection;
 
-            // TODO: reverse DNS lookup for peer_name of the incoming connection for TLS client certificate verification purposes
-            tls_stream = createTLSStreamFL(http_stream, context.tlsContext, TLSStreamState.accepting, null, connection.remoteAddress);
-            http_stream = tls_stream;
-        }
-    }
+			// TODO: reverse DNS lookup for peer_name of the incoming connection for TLS client certificate verification purposes
+			tls_stream = createTLSStreamFL(http_stream, context.tlsContext, TLSStreamState.accepting, null, connection.remoteAddress);
+			http_stream = tls_stream;
+		}
+	}
 	handleHTTP1Request(connection, context);
 }
 
@@ -113,7 +113,7 @@ bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_
 
 	// some instances that live only while the request is running
 	//FreeListRef!HTTPServerRequest req = FreeListRef!HTTPServerRequest(reqtime, listen_info.bindPort);
-    auto req = HTTPServerRequest(reqtime, listen_info.bindPort);
+	auto req = HTTPServerRequest(reqtime, listen_info.bindPort);
 
 	FreeListRef!TimeoutHTTPInputStream timeout_http_input_stream;
 	FreeListRef!LimitedHTTPInputStream limited_http_input_stream;
@@ -139,17 +139,17 @@ bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_
 	// Create the response object
 	InterfaceProxy!ConnectionStream cproxy = tcp_connection;
 	auto res = HTTPServerResponse(http_stream, cproxy, settings, request_allocator/*.Scoped_payload*/);
-    auto istls = listen_info.tlsContext !is null;
-    req.tls = istls;
-    res.tls = istls;
+	auto istls = listen_info.tlsContext !is null;
+	req.tls = istls;
+	res.tls = istls;
 
- 	if (req.tls) {
+	if (req.tls) {
 		version (HaveNoTLS) assert(false);
 		else {
 			static if (is(InterfaceProxy!ConnectionStream == ConnectionStream))
 				req.clientCertificate = (cast(TLSStream)http_stream).peerCertificate;
 			else
-                req.clientCertificate = http_stream.extract!TLSStreamType.peerCertificate;
+				req.clientCertificate = http_stream.extract!TLSStreamType.peerCertificate;
 				assert(false);
 		}
 	}
@@ -265,7 +265,7 @@ bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_
 			}
 		}
 
-        // eagerly parse the URL as its lightweight and defacto @nogc
+		// eagerly parse the URL as its lightweight and defacto @nogc
 		auto url = URL.parse(req.requestURI);
 		req.queryString = url.queryString;
 		req.username = url.username;
@@ -382,7 +382,7 @@ final class TimeoutHTTPInputStream : InputStream {
 
 	@property bool empty() { enforce(m_in, "InputStream missing"); return m_in.empty(); }
 	@property ulong leastSize() { enforce(m_in, "InputStream missing"); return m_in.leastSize();  }
-	@property bool dataAvailableForRead() {  enforce(m_in, "InputStream missing"); return m_in.dataAvailableForRead; }
+	@property bool dataAvailableForRead() {	 enforce(m_in, "InputStream missing"); return m_in.dataAvailableForRead; }
 	const(ubyte)[] peek() { return m_in.peek(); }
 
 	size_t read(scope ubyte[] dst, IOMode mode)

--- a/source/vibe/http/log.d
+++ b/source/vibe/http/log.d
@@ -1,0 +1,259 @@
+/**
+	A HTTP 1.1/1.0 server implementation.
+
+	Copyright: © 2012-2013 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Sönke Ludwig, Jan Krüger
+*/
+module vibe.http.log;
+
+import vibe.core.file;
+import vibe.core.log;
+import vibe.core.sync : InterruptibleTaskMutex, performLocked;
+import vibe.http.server;
+import vibe.utils.array : FixedAppender;
+
+import std.array;
+import std.conv;
+import std.exception;
+import std.string;
+
+
+class HTTPLogger {
+	@safe:
+
+	private {
+		string m_format;
+		const(HTTPServerSettings) m_settings;
+		InterruptibleTaskMutex m_mutex;
+		Appender!(char[]) m_lineAppender;
+	}
+
+	this(in HTTPServerSettings settings, string format)
+	{
+		m_format = format;
+		m_settings = settings;
+		m_mutex = new InterruptibleTaskMutex;
+		m_lineAppender.reserve(2048);
+	}
+
+	void close() {}
+
+	final void log(scope HTTPServerRequest req, scope HTTPServerResponse res)
+	{
+		m_mutex.performLocked!(() @safe {
+			m_lineAppender.clear();
+			formatApacheLog(m_lineAppender, m_format, req, res, m_settings);
+			writeLine(m_lineAppender.data);
+		});
+	}
+
+	protected abstract void writeLine(const(char)[] ln);
+}
+
+
+final class HTTPConsoleLogger : HTTPLogger {
+@safe:
+
+	this(HTTPServerSettings settings, string format)
+	{
+		super(settings, format);
+	}
+
+	protected override void writeLine(const(char)[] ln)
+	{
+		logInfo("%s", ln);
+	}
+}
+
+
+final class HTTPFileLogger : HTTPLogger {
+@safe:
+
+	private {
+		FileStream m_stream;
+	}
+
+	this(HTTPServerSettings settings, string format, string filename)
+	{
+		m_stream = openFile(filename, FileMode.append);
+		super(settings, format);
+	}
+
+	override void close()
+	{
+		m_stream.close();
+		m_stream = FileStream.init;
+	}
+
+	protected override void writeLine(const(char)[] ln)
+	{
+		assert(!!m_stream);
+		m_stream.write(ln);
+		m_stream.write("\n");
+		m_stream.flush();
+	}
+}
+
+void formatApacheLog(R)(ref R ln, string format, scope HTTPServerRequest req, scope HTTPServerResponse res, in HTTPServerSettings settings)
+@safe {
+	import std.format : formattedWrite;
+	enum State {Init, Directive, Status, Key, Command}
+
+	State state = State.Init;
+	bool conditional = false;
+	bool negate = false;
+	bool match = false;
+	string statusStr;
+	string key = "";
+	while( format.length > 0 ) {
+		final switch(state) {
+			case State.Init:
+				auto idx = format.indexOf('%');
+				if( idx < 0 ) {
+					ln.put( format );
+					format = "";
+				} else {
+					ln.put( format[0 .. idx] );
+					format = format[idx+1 .. $];
+
+					state = State.Directive;
+				}
+				break;
+			case State.Directive:
+				if( format[0] == '!' ) {
+					conditional = true;
+					negate = true;
+					format = format[1 .. $];
+					state = State.Status;
+				} else if( format[0] == '%' ) {
+					ln.put("%");
+					format = format[1 .. $];
+					state = State.Init;
+				} else if( format[0] == '{' ) {
+					format = format[1 .. $];
+					state = State.Key;
+				} else if( format[0] >= '0' && format[0] <= '9' ) {
+					conditional = true;
+					state = State.Status;
+				} else {
+					state = State.Command;
+				}
+				break;
+			case State.Status:
+				if( format[0] >= '0' && format[0] <= '9' ) {
+					statusStr ~= format[0];
+					format = format[1 .. $];
+				} else if( format[0] == ',' ) {
+					statusStr = "";
+					format = format[1 .. $];
+				} else if( format[0] == '{' ) {
+					format = format[1 .. $];
+					state = State.Key;
+				} else {
+					state = State.Command;
+				}
+				if (statusStr.length == 3 && !match) {
+					auto status = parse!int(statusStr);
+					match = status == res.statusCode;
+				}
+				break;
+			case State.Key:
+				auto idx = format.indexOf('}');
+				enforce(idx > -1, "Missing '}'");
+				key = format[0 .. idx];
+				format = format[idx+1 .. $];
+				state = State.Command;
+				break;
+			case State.Command:
+				if( conditional && negate == match ) {
+					ln.put('-');
+					format = format[1 .. $];
+					state = State.Init;
+					break;
+				}
+				switch(format[0]) {
+					case 'a': //Remote IP-address
+						ln.put(req.peer);
+						break;
+					//TODO case 'A': //Local IP-address
+					//case 'B': //Size of Response in bytes, excluding headers
+					case 'b': //same as 'B' but a '-' is written if no bytes where sent
+						if (!res.bytesWritten) ln.put('-');
+						else formattedWrite(() @trusted { return &ln; } (), "%s", res.bytesWritten);
+						break;
+					case 'C': //Cookie content {cookie}
+						import std.algorithm : joiner;
+						enforce(key != "", "cookie name missing");
+						auto values = req.cookies.getAll(key);
+						if (values.length) ln.formattedWrite("%s", values.joiner(";"));
+						else ln.put("-");
+						break;
+					case 'D': //The time taken to serve the request
+						auto d = res.timeFinalized - req.timeCreated;
+						formattedWrite(() @trusted { return &ln; } (), "%s", d.total!"msecs"());
+						break;
+					//case 'e': //Environment variable {variable}
+					//case 'f': //Filename
+					case 'h': //Remote host
+						ln.put(req.peer);
+						break;
+					case 'H': //The request protocol
+						ln.put("HTTP");
+						break;
+					case 'i': //Request header {header}
+						enforce(key != "", "header name missing");
+						if (auto pv = key in req.headers) ln.put(*pv);
+						else ln.put("-");
+						break;
+					case 'm': //Request method
+						ln.put(httpMethodString(req.method));
+						break;
+					case 'o': //Response header {header}
+						enforce(key != "", "header name missing");
+						if( auto pv = key in res.headers ) ln.put(*pv);
+						else ln.put("-");
+						break;
+					case 'p': //port
+						formattedWrite(() @trusted { return &ln; } (), "%s", settings.port);
+						break;
+					//case 'P': //Process ID
+					case 'q': //query string (with prepending '?')
+						ln.put("?");
+						ln.put(req.queryString);
+						break;
+					case 'r': //First line of Request
+						ln.put(httpMethodString(req.method));
+						ln.put(' ');
+						ln.put(req.requestURL);
+						ln.put(' ');
+						ln.put(getHTTPVersionString(req.httpVersion));
+						break;
+					case 's': //Status
+						formattedWrite(() @trusted { return &ln; } (), "%s", res.statusCode);
+						break;
+					case 't': //Time the request was received {format}
+						ln.put(req.timeCreated.toSimpleString());
+						break;
+					case 'T': //Time taken to server the request in seconds
+						auto d = res.timeFinalized - req.timeCreated;
+						formattedWrite(() @trusted { return &ln; } (), "%s", d.total!"seconds");
+						break;
+					case 'u': //Remote user
+						ln.put(req.username.length ? req.username : "-");
+						break;
+					case 'U': //The URL path without query string
+						ln.put(req.path);
+						break;
+					case 'v': //Server name
+						ln.put(req.host.length ? req.host : "-");
+						break;
+					default:
+						throw new Exception("Unknown directive '" ~ format[0] ~ "' in log format string");
+				}
+				state = State.Init;
+				format = format[1 .. $];
+				break;
+		}
+	}
+}

--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -247,7 +247,7 @@ final class URLRouter : HTTPServerRequestHandler {
 		static if (
 				is(Handler : HTTPServerRequestDelegate) ||
 				is(Handler : HTTPServerRequestFunction) ||
-				is(Handler : HTTPServerRequestHandler) 
+				is(Handler : HTTPServerRequestHandler)
 				//is(Handler : HTTPServerRequestDelegateS) ||
 				//is(Handler : HTTPServerRequestFunctionS) ||
 				//is(Handler : HTTPServerRequestHandlerS)
@@ -319,7 +319,7 @@ final class URLRouter : HTTPServerRequestHandler {
 	//void setup()
 	//{
 		//auto router = new URLRouter;
-		//// Matches all GET requests for /users[>/groups/* and places
+		//// Matches all GET requests for /users[>/groups[> and places
 		//// the place holders in req.params as 'username' and 'groupname'.
 		//router.get("/users/:username/groups/:groupname", &addGroup);
 

--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -1,0 +1,1288 @@
+/**
+	Pattern based URL router for HTTP request.
+
+	See `URLRouter` for more details.
+
+	Copyright: © 2012-2015 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Sönke Ludwig
+*/
+module vibe.http.router;
+
+public import vibe.http.server;
+
+import vibe.core.log;
+
+import std.functional;
+
+
+/**
+	Routes HTTP requests based on the request method and URL.
+
+	Routes are matched using a special URL match string that supports two forms
+	of placeholders. See the sections below for more details.
+
+	Registered routes are matched according to the same sequence as initially
+	specified using `match`, `get`, `post` etc. Matching ends as soon as a route
+	handler writes a response using `res.writeBody()` or similar means. If no
+	route matches or if no route handler writes a response, the router will
+	simply not handle the request and the HTTP server will automatically
+	generate a 404 error.
+
+	Match_patterns:
+		Match patterns are character sequences that can optionally contain
+		placeholders or raw wildcards ("*"). Raw wild cards match any character
+		sequence, while placeholders match only sequences containing no slash
+		("/") characters.
+
+		Placeholders are started using a colon (":") and are directly followed
+		by their name. The first "/" character (or the end of the match string)
+		denotes the end of the placeholder name. The part of the string that
+		matches a placeholder will be stored in the `HTTPServerRequest.params`
+		map using the placeholder name as the key.
+
+		Match strings are subject to the following rules:
+		$(UL
+			$(LI A raw wildcard ("*") may only occur at the end of the match string)
+			$(LI At least one character must be placed between any two placeholders or wildcards)
+			$(LI The maximum allowed number of placeholders in a single match string is 64)
+		)
+
+	Match_String_Examples:
+		$(UL
+			$(LI `"/foo/bar"` matches only `"/foo/bar"` itself)
+			$(LI `"/foo/*"` matches `"/foo/"`, `"/foo/bar"`, `"/foo/bar/baz"` or _any other string beginning with `"/foo/"`)
+			$(LI `"/:x/"` matches `"/foo/"`, `"/bar/"` and similar strings (and stores `"foo"`/`"bar"` in `req.params["x"]`), but not `"/foo/bar/"`)
+			$(LI Matching partial path entries with wildcards is possible: `"/foo:x"` matches `"/foo"`, `"/foobar"`, but not `"/foo/bar"`)
+			$(LI Multiple placeholders and raw wildcards can be combined: `"/:x/:y/*"`)
+		)
+*/
+final class URLRouter : HTTPServerRequestHandler {
+	@safe:
+
+	private {
+		MatchTree!Route m_routes;
+		string m_prefix;
+		bool m_computeBasePath;
+	}
+
+	this(string prefix = null)
+	{
+		m_prefix = prefix;
+	}
+
+	/** Sets a common prefix for all registered routes.
+
+		All routes will implicitly have this prefix prepended before being
+		matched against incoming requests.
+	*/
+	@property string prefix() const { return m_prefix; }
+
+	/** Controls the computation of the "routerRootDir" parameter.
+
+		This parameter is available as `req.params["routerRootDir"]` and
+		contains the relative path to the base path of the router. The base
+		path is determined by the `prefix` property.
+
+		Note that this feature currently is requires dynamic memory allocations
+		and is opt-in for this reason.
+	*/
+	@property void enableRootDir(bool enable) { m_computeBasePath = enable; }
+
+	/// Returns a single route handle to conveniently register multiple methods.
+	URLRoute route(string path)
+	in { assert(path.length, "Cannot register null or empty path!"); }
+	body { return URLRoute(this, path); }
+
+	///
+	unittest {
+		void getFoo(scope HTTPServerRequest req, scope HTTPServerResponse res) { /* ... */ }
+		void postFoo(scope HTTPServerRequest req, scope HTTPServerResponse res) { /* ... */ }
+		void deleteFoo(scope HTTPServerRequest req, scope HTTPServerResponse res) { /* ... */ }
+
+		auto r = new URLRouter;
+
+		// using 'with' statement
+		with (r.route("/foo")) {
+			get(&getFoo);
+			post(&postFoo);
+			delete_(&deleteFoo);
+		}
+
+		// using method chaining
+		r.route("/foo")
+			.get(&getFoo)
+			.post(&postFoo)
+			.delete_(&deleteFoo);
+
+		// without using route()
+		r.get("/foo", &getFoo);
+		r.post("/foo", &postFoo);
+		r.delete_("/foo", &deleteFoo);
+	}
+
+	/// Adds a new route for requests matching the specified HTTP method and pattern.
+	URLRouter match(Handler)(HTTPMethod method, string path, Handler handler)
+		if (isValidHandler!Handler)
+	{
+		import std.algorithm;
+		assert(path.length, "Cannot register null or empty path!");
+		assert(count(path, ':') <= maxRouteParameters, "Too many route parameters");
+		logDebug("add route %s %s", method, path);
+		m_routes.addTerminal(path, Route(method, path, handlerDelegate(handler)));
+		return this;
+	}
+
+	/// ditto
+	URLRouter match(HTTPMethod method, string path, HTTPServerRequestDelegate handler)
+	{
+		return match!HTTPServerRequestDelegate(method, path, handler);
+	}
+
+	/// Adds a new route for GET requests matching the specified pattern.
+	URLRouter get(Handler)(string url_match, Handler handler) if (isValidHandler!Handler) { return match(HTTPMethod.GET, url_match, handler); }
+	/// ditto
+	URLRouter get(string url_match, HTTPServerRequestDelegate handler) { return match(HTTPMethod.GET, url_match, handler); }
+
+	/// Adds a new route for POST requests matching the specified pattern.
+	URLRouter post(Handler)(string url_match, Handler handler) if (isValidHandler!Handler) { return match(HTTPMethod.POST, url_match, handler); }
+	/// ditto
+	URLRouter post(string url_match, HTTPServerRequestDelegate handler) { return match(HTTPMethod.POST, url_match, handler); }
+
+	/// Adds a new route for PUT requests matching the specified pattern.
+	URLRouter put(Handler)(string url_match, Handler handler) if (isValidHandler!Handler) { return match(HTTPMethod.PUT, url_match, handler); }
+	/// ditto
+	URLRouter put(string url_match, HTTPServerRequestDelegate handler) { return match(HTTPMethod.PUT, url_match, handler); }
+
+	/// Adds a new route for DELETE requests matching the specified pattern.
+	URLRouter delete_(Handler)(string url_match, Handler handler) if (isValidHandler!Handler) { return match(HTTPMethod.DELETE, url_match, handler); }
+	/// ditto
+	URLRouter delete_(string url_match, HTTPServerRequestDelegate handler) { return match(HTTPMethod.DELETE, url_match, handler); }
+
+	/// Adds a new route for PATCH requests matching the specified pattern.
+	URLRouter patch(Handler)(string url_match, Handler handler) if (isValidHandler!Handler) { return match(HTTPMethod.PATCH, url_match, handler); }
+	/// ditto
+	URLRouter patch(string url_match, HTTPServerRequestDelegate handler) { return match(HTTPMethod.PATCH, url_match, handler); }
+
+	/// Adds a new route for requests matching the specified pattern, regardless of their HTTP verb.
+	URLRouter any(Handler)(string url_match, Handler handler)
+	{
+		import std.traits;
+		static HTTPMethod[] all_methods = [EnumMembers!HTTPMethod];
+		foreach(immutable method; all_methods)
+			match(method, url_match, handler);
+
+		return this;
+	}
+	/// ditto
+	URLRouter any(string url_match, HTTPServerRequestDelegate handler) { return any!HTTPServerRequestDelegate(url_match, handler); }
+
+
+	/** Rebuilds the internal matching structures to account for newly added routes.
+
+		This should be used after a lot of routes have been added to the router, to
+		force eager computation of the match structures. The alternative is to
+		let the router lazily compute the structures when the first request happens,
+		which can delay this request.
+	*/
+	void rebuild()
+	{
+		m_routes.rebuildGraph();
+	}
+
+	/// Handles a HTTP request by dispatching it to the registered route handlers.
+	void handleRequest(HTTPServerRequest req, HTTPServerResponse res)
+	{
+		auto method = req.method;
+
+		string calcBasePath()
+		@safe {
+			import vibe.inet.path;
+			auto p = InetPath(prefix.length ? prefix : "/");
+			p.endsWithSlash = true;
+			return p.relativeToWeb(InetPath(req.path)).toString();
+		}
+
+		auto path = req.path;
+		if (path.length < m_prefix.length || path[0 .. m_prefix.length] != m_prefix) return;
+		path = path[m_prefix.length .. $];
+
+		while (true) {
+			bool done = m_routes.match(path, (ridx, scope values) @safe {
+				auto r = () @trusted { return &m_routes.getTerminalData(ridx); } ();
+				if (r.method != method) return false;
+
+				logDebugV("route match: %s -> %s %s %s", req.path, r.method, r.pattern, values);
+				foreach (i, v; values) req.params[m_routes.getTerminalVarNames(ridx)[i]] = v;
+				if (m_computeBasePath) req.params["routerRootDir"] = calcBasePath();
+				r.cb(req, res);
+				return res.headerWritten;
+			});
+			if (done) return;
+
+			if (method == HTTPMethod.HEAD) method = HTTPMethod.GET;
+			else break;
+		}
+
+		logDebug("no route match: %s %s", req.method, req.requestURL);
+	}
+
+	/// Returns all registered routes as const AA
+	const(Route)[] getAllRoutes()
+	{
+		auto routes = new Route[m_routes.terminalCount];
+		foreach (i, ref r; routes)
+			r = m_routes.getTerminalData(i);
+		return routes;
+	}
+
+	template isValidHandler(Handler) {
+		@system {
+			alias USDel = void delegate(HTTPServerRequest, HTTPServerResponse) @system;
+			alias USFun = void function(HTTPServerRequest, HTTPServerResponse) @system;
+			alias USDelS = void delegate(scope HTTPServerRequest, scope HTTPServerResponse) @system;
+			alias USFunS = void function(scope HTTPServerRequest, scope HTTPServerResponse) @system;
+		}
+
+		static if (
+				is(Handler : HTTPServerRequestDelegate) ||
+				is(Handler : HTTPServerRequestFunction) ||
+				is(Handler : HTTPServerRequestHandler) 
+				//is(Handler : HTTPServerRequestDelegateS) ||
+				//is(Handler : HTTPServerRequestFunctionS) ||
+				//is(Handler : HTTPServerRequestHandlerS)
+			)
+		{
+			enum isValidHandler = true;
+		} else static if (
+				is(Handler : USDel) || is(Handler : USFun) ||
+				is(Handler : USDelS) || is(Handler : USFunS)
+			)
+		{
+			enum isValidHandler = true;
+		} else {
+			enum isValidHandler = false;
+		}
+	}
+
+	static void delegate(HTTPServerRequest, HTTPServerResponse) @safe handlerDelegate(Handler)(Handler handler)
+	{
+		import std.traits : isFunctionPointer;
+		static if (isFunctionPointer!Handler) return handlerDelegate(() @trusted { return toDelegate(handler); } ());
+		else static if (is(Handler == class) || is(Handler == interface)) return &handler.handleRequest;
+		else static if (__traits(compiles, () @safe { handler(HTTPServerRequest.init, HTTPServerResponse.init); } ())) return handler;
+		else return (req, res) @trusted { handler(req, res); };
+	}
+
+	unittest {
+		static assert(isValidHandler!HTTPServerRequestFunction);
+		static assert(isValidHandler!HTTPServerRequestDelegate);
+		static assert(isValidHandler!HTTPServerRequestHandler);
+		//static assert(isValidHandler!HTTPServerRequestFunctionS);
+		//static assert(isValidHandler!HTTPServerRequestDelegateS);
+		//static assert(isValidHandler!HTTPServerRequestHandlerS);
+		static assert(isValidHandler!(void delegate(HTTPServerRequest req, HTTPServerResponse res) @system));
+		static assert(isValidHandler!(void function(HTTPServerRequest req, HTTPServerResponse res) @system));
+		static assert(isValidHandler!(void delegate(scope HTTPServerRequest req, scope HTTPServerResponse res) @system));
+		static assert(isValidHandler!(void function(scope HTTPServerRequest req, scope HTTPServerResponse res) @system));
+		static assert(!isValidHandler!(int delegate(HTTPServerRequest req, HTTPServerResponse res) @system));
+		static assert(!isValidHandler!(int delegate(HTTPServerRequest req, HTTPServerResponse res) @safe));
+		void test(H)(H h)
+		{
+			static assert(isValidHandler!H);
+		}
+		test((HTTPServerRequest req, HTTPServerResponse res) {});
+	}
+}
+
+///
+//@safe unittest {
+	//import vibe.http.fileserver;
+
+	//void addGroup(HTTPServerRequest req, HTTPServerResponse res)
+	//{
+		//// Route variables are accessible via the params map
+		//logInfo("Getting group %s for user %s.", req.params["groupname"], req.params["username"]);
+	//}
+
+	//void deleteUser(HTTPServerRequest req, HTTPServerResponse res)
+	//{
+		//// ...
+	//}
+
+	//void auth(HTTPServerRequest req, HTTPServerResponse res)
+	//{
+		//// TODO: check req.session to see if a user is logged in and
+		////       write an error page or throw an exception instead.
+	//}
+
+	//void setup()
+	//{
+		//auto router = new URLRouter;
+		//// Matches all GET requests for /users[>/groups/* and places
+		//// the place holders in req.params as 'username' and 'groupname'.
+		//router.get("/users/:username/groups/:groupname", &addGroup);
+
+		//// Matches all requests. This can be useful for authorization and
+		//// similar tasks. The auth method will only write a response if the
+		//// user is _not_ authorized. Otherwise, the router will fall through
+		//// and continue with the following routes.
+		//router.any("*", &auth);
+
+		//// Matches a POST request
+		//router.post("/users/:username/delete", &deleteUser);
+
+		//// Matches all GET requests in /static/ such as /static/img.png or
+		//// /static/styles/sty.css
+		//router.get("/static/*", serveStaticFiles("public/"));
+
+		//// Setup a HTTP server...
+		//auto settings = new HTTPServerSettings;
+		//// ...
+
+		//// The router can be directly passed to the listenHTTP function as
+		//// the main request handler.
+		//listenHTTP(settings, router);
+	//}
+//}
+
+/** Using nested routers to map components to different sub paths. A component
+	could for example be an embedded blog engine.
+*/
+@safe unittest {
+	// some embedded component:
+
+	void showComponentHome(HTTPServerRequest req, HTTPServerResponse res)
+	{
+		// ...
+	}
+
+	void showComponentUser(HTTPServerRequest req, HTTPServerResponse res)
+	{
+		// ...
+	}
+
+	void registerComponent(URLRouter router)
+	{
+		router.get("/", &showComponentHome);
+		router.get("/users/:user", &showComponentUser);
+	}
+
+	// main application:
+
+	void showHome(HTTPServerRequest req, HTTPServerResponse res)
+	{
+		// ...
+	}
+
+	void setup()
+	{
+		auto c1router = new URLRouter("/component1");
+		registerComponent(c1router);
+
+		auto mainrouter = new URLRouter;
+		mainrouter.get("/", &showHome);
+		// forward all unprocessed requests to the component router
+		mainrouter.any("*", c1router);
+
+		// now the following routes will be matched:
+		// / -> showHome
+		// /component1/ -> showComponentHome
+		// /component1/users/:user -> showComponentUser
+
+		// Start the HTTP server
+		auto settings = new HTTPServerSettings;
+		// ...
+		//listenHTTP(settings, mainrouter);
+
+		listenHTTP!mainrouter(settings);
+	}
+}
+
+@safe unittest { // issue #1668
+	auto r = new URLRouter;
+	r.get("/", (req, res) {
+		if ("foo" in req.headers)
+			res.writeBody("bar");
+	});
+
+	r.get("/", (scope req, scope res) {
+		if ("foo" in req.headers)
+			res.writeBody("bar");
+	});
+	r.get("/", (req, res) {});
+	r.post("/", (req, res) {});
+	r.put("/", (req, res) {});
+	r.delete_("/", (req, res) {});
+	r.patch("/", (req, res) {});
+	r.any("/", (req, res) {});
+}
+
+@safe unittest { // issue #1866
+	auto r = new URLRouter;
+	r.match(HTTPMethod.HEAD, "/foo", (scope req, scope res) { res.writeVoidBody; });
+	r.match(HTTPMethod.HEAD, "/foo", (req, res) { res.writeVoidBody; });
+	r.match(HTTPMethod.HEAD, "/foo", (scope HTTPServerRequest req, scope HTTPServerResponse res) { res.writeVoidBody; });
+	r.match(HTTPMethod.HEAD, "/foo", (HTTPServerRequest req, HTTPServerResponse res) { res.writeVoidBody; });
+
+	auto r2 = new URLRouter;
+	r.match(HTTPMethod.HEAD, "/foo", r2);
+}
+
+@safe unittest {
+	import vibe.inet.url;
+
+	auto router = new URLRouter;
+	string result;
+	void a(HTTPServerRequest req, HTTPServerResponse) { result ~= "A"; }
+	void b(HTTPServerRequest req, HTTPServerResponse) { result ~= "B"; }
+	void c(HTTPServerRequest req, HTTPServerResponse) { assert(req.params["test"] == "x", "Wrong variable contents: "~req.params["test"]); result ~= "C"; }
+	void d(HTTPServerRequest req, HTTPServerResponse) { assert(req.params["test"] == "y", "Wrong variable contents: "~req.params["test"]); result ~= "D"; }
+	router.get("/test", &a);
+	router.post("/test", &b);
+	router.get("/a/:test", &c);
+	router.get("/a/:test/", &d);
+
+	auto res = createTestHTTPServerResponse();
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/")), res);
+	assert(result == "", "Matched for non-existent / path");
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/test")), res);
+	assert(result == "A", "Didn't match a simple GET request");
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/test"), HTTPMethod.POST), res);
+	assert(result == "AB", "Didn't match a simple POST request");
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/a/"), HTTPMethod.GET), res);
+	assert(result == "AB", "Matched empty variable. "~result);
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/a/x"), HTTPMethod.GET), res);
+	assert(result == "ABC", "Didn't match a trailing 1-character var.");
+	// currently fails due to Path not accepting "//"
+	//router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/a//"), HTTPMethod.GET), res);
+	//assert(result == "ABC", "Matched empty string or slash as var. "~result);
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/a/y/"), HTTPMethod.GET), res);
+	assert(result == "ABCD", "Didn't match 1-character infix variable.");
+}
+
+@safe unittest {
+	import vibe.inet.url;
+
+	auto router = new URLRouter("/test");
+
+	string result;
+	void a(HTTPServerRequest req, HTTPServerResponse) { result ~= "A"; }
+	void b(HTTPServerRequest req, HTTPServerResponse) { result ~= "B"; }
+	router.get("/x", &a);
+	router.get("/y", &b);
+
+	auto res = createTestHTTPServerResponse();
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/test")), res);
+	assert(result == "");
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/test/x")), res);
+	assert(result == "A");
+	router.handleRequest(createTestHTTPServerRequest(URL("http://localhost/test/y")), res);
+	assert(result == "AB");
+}
+
+@safe unittest {
+	string ensureMatch(string pattern, string local_uri, string[string] expected_params = null)
+	{
+		import vibe.inet.url : URL;
+		string ret = local_uri ~ " did not match " ~ pattern;
+		auto r = new URLRouter;
+		r.get(pattern, (req, res) {
+			ret = null;
+			foreach (k, v; expected_params) {
+				if (k !in req.params) { ret = "Parameter "~k~" was not matched."; return; }
+				if (req.params[k] != v) { ret = "Parameter "~k~" is '"~req.params[k]~"' instead of '"~v~"'."; return; }
+			}
+		});
+		auto req = createTestHTTPServerRequest(URL("http://localhost"~local_uri));
+		auto res = createTestHTTPServerResponse();
+		r.handleRequest(req, res);
+		return ret;
+	}
+
+	assert(ensureMatch("/foo bar/", "/foo%20bar/") is null);   // normalized pattern: "/foo%20bar/"
+	//assert(ensureMatch("/foo%20bar/", "/foo%20bar/") is null); // normalized pattern: "/foo%20bar/"
+	assert(ensureMatch("/foo/bar/", "/foo/bar/") is null);     // normalized pattern: "/foo/bar/"
+	//assert(ensureMatch("/foo/bar/", "/foo%2fbar/") !is null);
+	//assert(ensureMatch("/foo%2fbar/", "/foo%2fbar/") is null); // normalized pattern: "/foo%2Fbar/"
+	//assert(ensureMatch("/foo%2Fbar/", "/foo%2fbar/") is null); // normalized pattern: "/foo%2Fbar/"
+	//assert(ensureMatch("/foo%2fbar/", "/foo%2Fbar/") is null);
+	//assert(ensureMatch("/foo%2fbar/", "/foo/bar/") !is null);
+	//assert(ensureMatch("/:foo/", "/foo%2Fbar/", ["foo": "foo/bar"]) is null);
+	assert(ensureMatch("/:foo/", "/foo/bar/") !is null);
+}
+
+
+/**
+	Convenience abstraction for a single `URLRouter` route.
+
+	See `URLRouter.route` for a usage example.
+*/
+struct URLRoute {
+@safe:
+
+	URLRouter router;
+	string path;
+
+	ref URLRoute get(Handler)(Handler h) { router.get(path, h); return this; }
+	ref URLRoute post(Handler)(Handler h) { router.post(path, h); return this; }
+	ref URLRoute put(Handler)(Handler h) { router.put(path, h); return this; }
+	ref URLRoute delete_(Handler)(Handler h) { router.delete_(path, h); return this; }
+	ref URLRoute patch(Handler)(Handler h) { router.patch(path, h); return this; }
+	ref URLRoute any(Handler)(Handler h) { router.any(path, h); return this; }
+	ref URLRoute match(Handler)(HTTPMethod method, Handler h) { router.match(method, path, h); return this; }
+}
+
+
+private enum maxRouteParameters = 64;
+
+private struct Route {
+	HTTPMethod method;
+	string pattern;
+	HTTPServerRequestDelegate cb;
+}
+
+private string skipPathNode(string str, ref size_t idx)
+@safe {
+	size_t start = idx;
+	while( idx < str.length && str[idx] != '/' ) idx++;
+	return str[start .. idx];
+}
+
+private string skipPathNode(ref string str)
+@safe {
+	size_t idx = 0;
+	auto ret = skipPathNode(str, idx);
+	str = str[idx .. $];
+	return ret;
+}
+
+private struct MatchTree(T) {
+@safe:
+
+	import std.algorithm : countUntil;
+	import std.array : array;
+
+	private {
+		alias NodeIndex = uint;
+		alias TerminalTagIndex = uint;
+		alias TerminalIndex = ushort;
+		alias VarIndex = ushort;
+
+		struct Node {
+			TerminalTagIndex terminalsStart; // slice into m_terminalTags
+			TerminalTagIndex terminalsEnd;
+			NodeIndex[ubyte.max+1] edges = NodeIndex.max; // character -> index into m_nodes
+		}
+		struct TerminalTag {
+			TerminalIndex index; // index into m_terminals array
+			VarIndex var = VarIndex.max; // index into Terminal.varNames/varValues or VarIndex.max
+		}
+		struct Terminal {
+			string pattern;
+			T data;
+			string[] varNames;
+			VarIndex[NodeIndex] varMap;
+		}
+		Node[] m_nodes; // all nodes as a single array
+		TerminalTag[] m_terminalTags;
+		Terminal[] m_terminals;
+
+		enum TerminalChar = 0;
+		bool m_upToDate = false;
+	}
+
+	@property size_t terminalCount() const { return m_terminals.length; }
+
+	void addTerminal(string pattern, T data)
+	{
+		assert(m_terminals.length < TerminalIndex.max, "Attempt to register too many routes.");
+		m_terminals ~= Terminal(pattern, data, null, null);
+		m_upToDate = false;
+	}
+
+	bool match(string text, scope bool delegate(size_t terminal, scope string[] vars) @safe del)
+	{
+		// lazily update the match graph
+		if (!m_upToDate) rebuildGraph();
+
+		return doMatch(text, del);
+	}
+
+	const(string)[] getTerminalVarNames(size_t terminal) const { return m_terminals[terminal].varNames; }
+	ref inout(T) getTerminalData(size_t terminal) inout { return m_terminals[terminal].data; }
+
+	void print()
+	const {
+		import std.algorithm : map;
+		import std.array : join;
+		import std.conv : to;
+		import std.range : iota;
+		import std.string : format;
+
+		logInfo("Nodes:");
+		foreach (i, n; m_nodes) {
+			logInfo("  %s %s", i, m_terminalTags[n.terminalsStart .. n.terminalsEnd]
+				.map!(t => format("T%s%s", t.index, t.var != VarIndex.max ? "("~m_terminals[t.index].varNames[t.var]~")" : "")).join(" "));
+			//logInfo("  %s %s-%s", i, n.terminalsStart, n.terminalsEnd);
+
+
+			static string mapChar(ubyte ch) {
+				if (ch == TerminalChar) return "$";
+				if (ch >= '0' && ch <= '9') return to!string(cast(dchar)ch);
+				if (ch >= 'a' && ch <= 'z') return to!string(cast(dchar)ch);
+				if (ch >= 'A' && ch <= 'Z') return to!string(cast(dchar)ch);
+				if (ch == '/') return "/";
+				if (ch == '^') return "^";
+				return ch.to!string;
+			}
+
+			void printRange(uint node, ubyte from, ubyte to)
+			{
+				if (to - from <= 10) logInfo("    %s -> %s", iota(from, cast(uint)to+1).map!(ch => mapChar(cast(ubyte)ch)).join("|"), node);
+				else logInfo("    %s-%s -> %s", mapChar(from), mapChar(to), node);
+			}
+
+			auto last_to = NodeIndex.max;
+			ubyte last_ch = 0;
+			foreach (ch, e; n.edges)
+				if (e != last_to) {
+					if (last_to != NodeIndex.max)
+						printRange(last_to, last_ch, cast(ubyte)(ch-1));
+					last_ch = cast(ubyte)ch;
+					last_to = e;
+				}
+			if (last_to != NodeIndex.max)
+				printRange(last_to, last_ch, ubyte.max);
+		}
+	}
+
+	private bool doMatch(string text, scope bool delegate(size_t terminal, scope string[] vars) @safe del)
+	const {
+		string[maxRouteParameters] vars_buf;// = void;
+
+		import std.algorithm : canFind;
+
+		// first, determine the end node, if any
+		auto n = matchTerminals(text);
+		if (!n) return false;
+
+		// then, go through the terminals and match their variables
+		foreach (ref t; m_terminalTags[n.terminalsStart .. n.terminalsEnd]) {
+			auto term = &m_terminals[t.index];
+			auto vars = vars_buf[0 .. term.varNames.length];
+			matchVars(vars, term, text);
+			if (vars.canFind!(v => v.length == 0)) continue; // all variables must be non-empty to match
+			if (del(t.index, vars)) return true;
+		}
+		return false;
+	}
+
+	private inout(Node)* matchTerminals(string text)
+	inout {
+		if (!m_nodes.length) return null;
+
+		auto n = &m_nodes[0];
+
+		// follow the path through the match graph
+		foreach (i, char ch; text) {
+			auto nidx = n.edges[cast(size_t)ch];
+			if (nidx == NodeIndex.max) return null;
+			n = &m_nodes[nidx];
+		}
+
+		// finally, find a matching terminal node
+		auto nidx = n.edges[TerminalChar];
+		if (nidx == NodeIndex.max) return null;
+		n = &m_nodes[nidx];
+		return n;
+	}
+
+	private void matchVars(string[] dst, in Terminal* term, string text)
+	const {
+		NodeIndex nidx = 0;
+		VarIndex activevar = VarIndex.max;
+		size_t activevarstart;
+
+		dst[] = null;
+
+		// folow the path throgh the match graph
+		foreach (i, char ch; text) {
+			auto var = term.varMap.get(nidx, VarIndex.max);
+
+			// detect end of variable
+			if (var != activevar && activevar != VarIndex.max) {
+				dst[activevar] = text[activevarstart .. i-1];
+				activevar = VarIndex.max;
+			}
+
+			// detect beginning of variable
+			if (var != VarIndex.max && activevar == VarIndex.max) {
+				activevar = var;
+				activevarstart = i;
+			}
+
+			nidx = m_nodes[nidx].edges[cast(ubyte)ch];
+			assert(nidx != NodeIndex.max);
+		}
+
+		// terminate any active varible with the end of the input string or with the last character
+		auto var = term.varMap.get(nidx, VarIndex.max);
+		if (activevar != VarIndex.max) dst[activevar] = text[activevarstart .. (var == activevar ? $ : $-1)];
+	}
+
+	private void rebuildGraph()
+	@trusted {
+		import std.array : appender;
+		import std.conv : to;
+
+		if (m_upToDate) return;
+		m_upToDate = true;
+
+		m_nodes = null;
+		m_terminalTags = null;
+
+		if (!m_terminals.length) return;
+
+		MatchGraphBuilder builder;
+		foreach (i, ref t; m_terminals) {
+			t.varNames = builder.insert(t.pattern, i.to!TerminalIndex);
+			assert(t.varNames.length <= VarIndex.max, "Too many variables in route.");
+		}
+		//builder.print();
+		builder.disambiguate();
+
+		auto nodemap = new NodeIndex[builder.m_nodes.length];
+		nodemap[] = NodeIndex.max;
+
+		auto nodes = appender!(Node[]);
+		nodes.reserve(1024);
+		auto termtags = appender!(TerminalTag[]);
+		termtags.reserve(1024);
+
+		NodeIndex process(NodeIndex n)
+		{
+			import std.algorithm : canFind;
+
+			if (nodemap[n] != NodeIndex.max) return nodemap[n];
+			auto nmidx = cast(NodeIndex)nodes.data.length;
+			nodemap[n] = nmidx;
+			nodes.put(Node.init);
+
+			Node nn;
+			nn.terminalsStart = termtags.data.length.to!TerminalTagIndex;
+			foreach (t; builder.m_nodes[n].terminals) {
+				auto var = cast(VarIndex)t.var;
+				assert(!termtags.data[nn.terminalsStart .. $].canFind!(u => u.index == t.index && u.var == var));
+				termtags ~= TerminalTag(cast(TerminalIndex)t.index, var);
+				if (var != VarIndex.max)
+					m_terminals[t.index].varMap[nmidx] = var;
+			}
+			nn.terminalsEnd = termtags.data.length.to!TerminalTagIndex;
+			foreach (ch, targets; builder.m_nodes[n].edges)
+				foreach (to; builder.m_edgeEntries.getItems(targets))
+					nn.edges[ch] = process(to);
+
+			nodes.data[nmidx] = nn;
+
+			return nmidx;
+		}
+		assert(builder.m_edgeEntries.hasLength(builder.m_nodes[0].edges['^'], 1),
+			"Graph must be disambiguated before purging.");
+		process(builder.m_edgeEntries.getItems(builder.m_nodes[0].edges['^']).front);
+
+		m_nodes = nodes.data;
+		m_terminalTags = termtags.data;
+
+		logDebug("Match tree has %s (of %s in the builder) nodes, %s terminals", m_nodes.length, builder.m_nodes.length, m_terminals.length);
+	}
+}
+
+unittest {
+	import std.string : format;
+	MatchTree!int m;
+
+	void testMatch(string str, size_t[] terms, string[] vars)
+	{
+		size_t[] mterms;
+		string[] mvars;
+		m.match(str, (t, scope vals) {
+			mterms ~= t;
+			mvars ~= vals;
+			return false;
+		});
+		assert(mterms == terms, format("Mismatched terminals: %s (expected %s)", mterms, terms));
+		assert(mvars == vars, format("Mismatched variables; %s (expected %s)", mvars, vars));
+	}
+
+	m.addTerminal("a", 0);
+	m.addTerminal("b", 0);
+	m.addTerminal("ab", 0);
+	m.rebuildGraph();
+	assert(m.getTerminalVarNames(0) == []);
+	assert(m.getTerminalVarNames(1) == []);
+	assert(m.getTerminalVarNames(2) == []);
+	testMatch("a", [0], []);
+	testMatch("ab", [2], []);
+	testMatch("abc", [], []);
+	testMatch("b", [1], []);
+
+	m = MatchTree!int.init;
+	m.addTerminal("ab", 0);
+	m.addTerminal("a*", 0);
+	m.rebuildGraph();
+	assert(m.getTerminalVarNames(0) == []);
+	assert(m.getTerminalVarNames(1) == []);
+	testMatch("a", [1], []);
+	testMatch("ab", [0, 1], []);
+	testMatch("abc", [1], []);
+
+	m = MatchTree!int.init;
+	m.addTerminal("ab", 0);
+	m.addTerminal("a:var", 0);
+	m.rebuildGraph();
+	assert(m.getTerminalVarNames(0) == []);
+	assert(m.getTerminalVarNames(1) == ["var"], format("%s", m.getTerminalVarNames(1)));
+	testMatch("a", [], []); // vars may not be empty
+	testMatch("ab", [0, 1], ["b"]);
+	testMatch("abc", [1], ["bc"]);
+
+	m = MatchTree!int.init;
+	m.addTerminal(":var1/:var2", 0);
+	m.addTerminal("a/:var3", 0);
+	m.addTerminal(":var4/b", 0);
+	m.rebuildGraph();
+	assert(m.getTerminalVarNames(0) == ["var1", "var2"]);
+	assert(m.getTerminalVarNames(1) == ["var3"]);
+	assert(m.getTerminalVarNames(2) == ["var4"]);
+	testMatch("a", [], []);
+	testMatch("a/a", [0, 1], ["a", "a", "a"]);
+	testMatch("a/b", [0, 1, 2], ["a", "b", "b", "a"]);
+	testMatch("a/bc", [0, 1], ["a", "bc", "bc"]);
+	testMatch("ab/b", [0, 2], ["ab", "b", "ab"]);
+	testMatch("ab/bc", [0], ["ab", "bc"]);
+
+	m = MatchTree!int.init;
+	m.addTerminal(":var1/", 0);
+	m.rebuildGraph();
+	assert(m.getTerminalVarNames(0) == ["var1"]);
+	testMatch("ab/", [0], ["ab"]);
+	testMatch("ab", [], []);
+	testMatch("/ab", [], []);
+	testMatch("a/b", [], []);
+	testMatch("ab//", [], []);
+}
+
+
+private struct MatchGraphBuilder {
+@safe:
+	import std.container.array : Array;
+	import std.array : array;
+	import std.algorithm : filter;
+	import std.string : format;
+
+	alias NodeIndex = uint;
+	alias TerminalIndex = ushort;
+	alias VarIndex = ushort;
+	alias NodeSet = LinkedSetBacking!NodeIndex.Handle;
+
+	private {
+		enum TerminalChar = 0;
+		struct TerminalTag {
+			TerminalIndex index;
+			VarIndex var = VarIndex.max;
+		}
+		struct Node {
+			Array!TerminalTag terminals;
+			NodeSet[ubyte.max+1] edges;
+		}
+		Array!Node m_nodes;
+		LinkedSetBacking!NodeIndex m_edgeEntries;
+	}
+
+	@disable this(this);
+
+	string[] insert(string pattern, TerminalIndex terminal)
+	{
+		import std.algorithm : canFind;
+
+		auto full_pattern = pattern;
+		string[] vars;
+		if (!m_nodes.length) addNode();
+
+		// create start node and connect to zero node
+		auto nidx = addNode();
+		addEdge(0, nidx, '^', terminal);
+
+		while (pattern.length) {
+			auto ch = pattern[0];
+			if (ch == '*') {
+				assert(pattern.length == 1, "Asterisk is only allowed at the end of a pattern: "~full_pattern);
+				pattern = null;
+
+				foreach (v; ubyte.min .. ubyte.max+1) {
+					if (v == TerminalChar) continue;
+					addEdge(nidx, nidx, cast(ubyte)v, terminal);
+				}
+			} else if (ch == ':') {
+				pattern = pattern[1 .. $];
+				auto name = skipPathNode(pattern);
+				assert(name.length > 0, "Missing placeholder name: "~full_pattern);
+				assert(!vars.canFind(name), "Duplicate placeholder name ':"~name~"': '"~full_pattern~"'");
+				auto varidx = cast(VarIndex)vars.length;
+				vars ~= name;
+				assert(!pattern.length || (pattern[0] != '*' && pattern[0] != ':'),
+					"Cannot have two placeholders directly follow each other.");
+
+				foreach (v; ubyte.min .. ubyte.max+1) {
+					if (v == TerminalChar || v == '/') continue;
+					addEdge(nidx, nidx, cast(ubyte)v, terminal, varidx);
+				}
+			} else {
+				nidx = addEdge(nidx, ch, terminal);
+				pattern = pattern[1 .. $];
+			}
+		}
+
+		addEdge(nidx, TerminalChar, terminal);
+		return vars;
+	}
+
+	void disambiguate()
+	@trusted {
+		import std.algorithm : map, sum;
+		import std.array : appender, join;
+
+		//logInfo("Disambiguate with %s initial nodes", m_nodes.length);
+		if (!m_nodes.length) return;
+
+		import vibe.utils.hashmap;
+		HashMap!(size_t, NodeIndex) combined_nodes;
+		Array!bool visited;
+		visited.length = m_nodes.length * 2;
+		Stack!NodeIndex node_stack;
+		node_stack.reserve(m_nodes.length);
+		node_stack.push(0);
+		while (!node_stack.empty) {
+			auto n = node_stack.pop();
+
+			while (n >= visited.length) visited.length = visited.length * 2;
+			if (visited[n]) continue;
+			//logInfo("Disambiguate %s (stack=%s)", n, node_stack.fill);
+			visited[n] = true;
+
+			foreach (ch; ubyte.min .. ubyte.max+1) {
+				auto chnodes = m_nodes[n].edges[ch];
+				size_t chhash = m_edgeEntries.getHash(chnodes);
+
+				// handle trivial cases
+				if (m_edgeEntries.hasMaxLength(chnodes, 1))
+					continue;
+
+				// generate combined state for ambiguous edges
+				if (auto pn = () @trusted { return chhash in combined_nodes; } ()) {
+					m_nodes[n].edges[ch] = m_edgeEntries.create(*pn);
+					assert(m_edgeEntries.hasLength(m_nodes[n].edges[ch], 1));
+					continue;
+				}
+
+				// for new combinations, create a new node
+				NodeIndex ncomb = addNode();
+				combined_nodes[chhash] = ncomb;
+
+				// write all edges
+				size_t idx = 0;
+				foreach (to_ch; ubyte.min .. ubyte.max+1) {
+					auto e = &m_nodes[ncomb].edges[to_ch];
+					foreach (chn; m_edgeEntries.getItems(chnodes))
+						m_edgeEntries.insert(e, m_edgeEntries.getItems(m_nodes[chn].edges[to_ch]));
+				}
+
+				// add terminal indices
+				foreach (chn; m_edgeEntries.getItems(chnodes))
+					foreach (t; m_nodes[chn].terminals)
+						addTerminal(ncomb, t.index, t.var);
+				foreach (i; 1 .. m_nodes[ncomb].terminals.length)
+					assert(m_nodes[ncomb].terminals[0] != m_nodes[ncomb].terminals[i]);
+
+				m_nodes[n].edges[ch] = m_edgeEntries.create(ncomb);
+				assert(m_edgeEntries.hasLength(m_nodes[n].edges[ch], 1));
+			}
+
+			// process nodes recursively
+			foreach (ch; ubyte.min .. ubyte.max+1) {
+				// should only have single out-edges now
+				assert(m_edgeEntries.hasMaxLength(m_nodes[n].edges[ch], 1));
+				foreach (e; m_edgeEntries.getItems(m_nodes[n].edges[ch]))
+					node_stack.push(e);
+			}
+		}
+
+		import std.algorithm.sorting : sort;
+		foreach (ref n; m_nodes)
+			n.terminals[].sort!((a, b) => a.index < b.index)();
+
+		debug logDebug("Disambiguate done: %s nodes, %s max stack size", m_nodes.length, node_stack.maxSize);
+	}
+
+	void print()
+	const @trusted {
+		import std.algorithm : map;
+		import std.array : join;
+		import std.conv : to;
+		import std.string : format;
+
+		logInfo("Nodes:");
+		size_t i = 0;
+		foreach (n; m_nodes) {
+			string mapChar(ubyte ch) {
+				if (ch == TerminalChar) return "$";
+				if (ch >= '0' && ch <= '9') return to!string(cast(dchar)ch);
+				if (ch >= 'a' && ch <= 'z') return to!string(cast(dchar)ch);
+				if (ch >= 'A' && ch <= 'Z') return to!string(cast(dchar)ch);
+				if (ch == '^') return "^";
+				if (ch == '/') return "/";
+				return format("$%s", ch);
+			}
+			logInfo("  %s: %s", i, n.terminals[].map!(t => t.var != VarIndex.max ? format("T%s(%s)", t.index, t.var) : format("T%s", t.index)).join(" "));
+			ubyte first_char;
+			size_t list_hash;
+			NodeSet list;
+
+			void printEdges(ubyte last_char) {
+				if (!list.empty) {
+					string targets;
+					foreach (tn; m_edgeEntries.getItems(list))
+						targets ~= format(" %s", tn);
+					if (targets.length > 0)
+						logInfo("    [%s ... %s] -> %s", mapChar(first_char), mapChar(last_char), targets);
+				}
+			}
+			foreach (ch, tnodes; n.edges) {
+				auto h = m_edgeEntries.getHash(tnodes);
+				if (h != list_hash) {
+					printEdges(cast(ubyte)(ch-1));
+					list_hash = h;
+					list = tnodes;
+					first_char = cast(ubyte)ch;
+				}
+			}
+			printEdges(ubyte.max);
+			i++;
+		}
+	}
+
+	private void addEdge(NodeIndex from, NodeIndex to, ubyte ch, TerminalIndex terminal, VarIndex var = VarIndex.max)
+	@trusted {
+		m_edgeEntries.insert(&m_nodes[from].edges[ch], to);
+		addTerminal(to, terminal, var);
+	}
+
+	private NodeIndex addEdge(NodeIndex from, ubyte ch, TerminalIndex terminal, VarIndex var = VarIndex.max)
+	@trusted {
+		import std.algorithm : canFind;
+		import std.string : format;
+		if (!m_nodes[from].edges[ch].empty)
+			assert(false, format("%s is in %s", ch, m_nodes[from].edges[]));
+		auto nidx = addNode();
+		addEdge(from, nidx, ch, terminal, var);
+		return nidx;
+	}
+
+	private void addTerminal(NodeIndex node, TerminalIndex terminal, VarIndex var)
+	@trusted {
+		foreach (ref t; m_nodes[node].terminals) {
+			if (t.index == terminal) {
+				if (t.var != VarIndex.max && t.var != var)
+					assert(false, format("Ambiguous route var match!? %s vs %s", t.var, var));
+				t.var = var;
+				return;
+			}
+		}
+		m_nodes[node].terminals ~= TerminalTag(terminal, var);
+	}
+
+	private NodeIndex addNode()
+	@trusted {
+		assert(m_nodes.length <= 1_000_000_000, "More than 1B nodes in tree!?");
+		auto idx = cast(NodeIndex)m_nodes.length;
+		m_nodes ~= Node.init;
+		return idx;
+	}
+}
+
+struct LinkedSetBacking(T) {
+	import std.container.array : Array;
+	import std.range : isInputRange;
+
+	static struct Handle {
+		uint index = uint.max;
+		@property bool empty() const { return index == uint.max; }
+	}
+
+	private {
+		static struct Entry {
+			uint next;
+			T value;
+		}
+
+		Array!Entry m_storage;
+
+		static struct Range {
+			private {
+				Array!Entry* backing;
+				uint index;
+			}
+
+			@property bool empty() const { return index == uint.max; }
+			@property ref const(T) front() const { return (*backing)[index].value; }
+
+			void popFront()
+			{
+				index = (*backing)[index].next;
+			}
+		}
+	}
+
+	@property Handle emptySet() { return Handle.init; }
+
+	Handle create(scope T[] items...)
+	{
+		Handle ret;
+		foreach (i; items)
+			ret.index = createNode(i, ret.index);
+		return ret;
+	}
+
+	void insert(Handle* h, T value)
+	{
+		/*foreach (c; getItems(*h))
+			if (value == c)
+				return;*/
+		h.index = createNode(value, h.index);
+	}
+
+	void insert(R)(Handle* h, R items)
+		if (isInputRange!R)
+	{
+		foreach (itm; items)
+			insert(h, itm);
+	}
+
+	size_t getHash(Handle sh)
+	const {
+		// NOTE: the returned hash is order independent, to avoid bogus
+		//       mismatches when comparing lists of different order
+		size_t ret = 0x72d2da6c;
+		while (sh != Handle.init) {
+			ret ^= (hashOf(m_storage[sh.index].value) ^ 0xb1bdfb8d) * 0x5dbf04a4;
+			sh.index = m_storage[sh.index].next;
+		}
+		return ret;
+	}
+
+	auto getItems(Handle sh) { return Range(&m_storage, sh.index); }
+	auto getItems(Handle sh) const { return Range(&(cast()this).m_storage, sh.index); }
+
+	bool hasMaxLength(Handle sh, size_t l)
+	const {
+		uint idx = sh.index;
+		do {
+			if (idx == uint.max) return true;
+			idx = m_storage[idx].next;
+		} while (l-- > 0);
+		return false;
+	}
+
+	bool hasLength(Handle sh, size_t l)
+	const {
+		uint idx = sh.index;
+		while (l-- > 0) {
+			if (idx == uint.max) return false;
+			idx = m_storage[idx].next;
+		}
+		return idx == uint.max;
+	}
+
+	private uint createNode(ref T val, uint next)
+	{
+		auto id = cast(uint)m_storage.length;
+		m_storage ~= Entry(next, val);
+		return id;
+	}
+}
+
+unittest {
+	import std.algorithm.comparison : equal;
+
+	LinkedSetBacking!int b;
+	auto s = b.emptySet;
+	assert(s.empty);
+	assert(b.getItems(s).empty);
+	s = b.create(3, 5, 7);
+	assert(b.getItems(s).equal([7, 5, 3]));
+	assert(!b.hasLength(s, 2));
+	assert(b.hasLength(s, 3));
+	assert(!b.hasLength(s, 4));
+	assert(!b.hasMaxLength(s, 2));
+	assert(b.hasMaxLength(s, 3));
+	assert(b.hasMaxLength(s, 4));
+
+	auto h = b.getHash(s);
+	assert(h != b.getHash(b.emptySet));
+	s = b.create(5, 3, 7);
+	assert(b.getHash(s) == h);
+
+	b.insert(&s, 11);
+	assert(b.hasLength(s, 4));
+	assert(b.getHash(s) != h);
+}
+
+private struct Stack(E)
+{
+	import std.range : isInputRange;
+
+	private {
+		E[] m_storage;
+		size_t m_fill;
+		debug size_t m_maxFill;
+	}
+
+	@property bool empty() const { return m_fill == 0; }
+
+	@property size_t fill() const { return m_fill; }
+
+	debug @property size_t maxSize() const { return m_maxFill; }
+
+	void reserve(size_t amt)
+	{
+		auto minsz = m_fill + amt;
+		if (m_storage.length < minsz) {
+			auto newlength = 64;
+			while (newlength < minsz) newlength *= 2;
+			m_storage.length = newlength;
+		}
+	}
+
+	void push(E el)
+	{
+		reserve(1);
+		m_storage[m_fill++] = el;
+		debug if (m_fill > m_maxFill) m_maxFill = m_fill;
+	}
+
+	void push(R)(R els)
+		if (isInputRange!R)
+	{
+		reserve(els.length);
+		foreach (el; els)
+			m_storage[m_fill++] = el;
+		debug if (m_fill > m_maxFill) m_maxFill = m_fill;
+	}
+
+	E pop()
+	{
+		assert(!empty, "Stack underflow.");
+		return m_storage[--m_fill];
+	}
+}

--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -313,7 +313,7 @@ final class URLRouter : HTTPServerRequestHandler {
 	//void auth(HTTPServerRequest req, HTTPServerResponse res)
 	//{
 		//// TODO: check req.session to see if a user is logged in and
-		////       write an error page or throw an exception instead.
+		////	   write an error page or throw an exception instead.
 	//}
 
 	//void setup()
@@ -391,7 +391,8 @@ final class URLRouter : HTTPServerRequestHandler {
 		// /component1/users/:user -> showComponentUser
 
 		// Start the HTTP server
-		auto settings = new HTTPServerSettings;
+		//auto settings = HTTPServerSettings;
+		HTTPServerSettings settings;
 		// ...
 		//listenHTTP(settings, mainrouter);
 
@@ -502,7 +503,7 @@ final class URLRouter : HTTPServerRequestHandler {
 
 	assert(ensureMatch("/foo bar/", "/foo%20bar/") is null);   // normalized pattern: "/foo%20bar/"
 	//assert(ensureMatch("/foo%20bar/", "/foo%20bar/") is null); // normalized pattern: "/foo%20bar/"
-	assert(ensureMatch("/foo/bar/", "/foo/bar/") is null);     // normalized pattern: "/foo/bar/"
+	assert(ensureMatch("/foo/bar/", "/foo/bar/") is null);	 // normalized pattern: "/foo/bar/"
 	//assert(ensureMatch("/foo/bar/", "/foo%2fbar/") !is null);
 	//assert(ensureMatch("/foo%2fbar/", "/foo%2fbar/") is null); // normalized pattern: "/foo%2Fbar/"
 	//assert(ensureMatch("/foo%2Fbar/", "/foo%2fbar/") is null); // normalized pattern: "/foo%2Fbar/"
@@ -639,8 +640,8 @@ private struct MatchTree(T) {
 
 			void printRange(uint node, ubyte from, ubyte to)
 			{
-				if (to - from <= 10) logInfo("    %s -> %s", iota(from, cast(uint)to+1).map!(ch => mapChar(cast(ubyte)ch)).join("|"), node);
-				else logInfo("    %s-%s -> %s", mapChar(from), mapChar(to), node);
+				if (to - from <= 10) logInfo("	%s -> %s", iota(from, cast(uint)to+1).map!(ch => mapChar(cast(ubyte)ch)).join("|"), node);
+				else logInfo("	%s-%s -> %s", mapChar(from), mapChar(to), node);
 			}
 
 			auto last_to = NodeIndex.max;
@@ -1055,7 +1056,7 @@ private struct MatchGraphBuilder {
 					foreach (tn; m_edgeEntries.getItems(list))
 						targets ~= format(" %s", tn);
 					if (targets.length > 0)
-						logInfo("    [%s ... %s] -> %s", mapChar(first_char), mapChar(last_char), targets);
+						logInfo("	[%s ... %s] -> %s", mapChar(first_char), mapChar(last_char), targets);
 				}
 			}
 			foreach (ch, tnodes; n.edges) {
@@ -1172,7 +1173,7 @@ struct LinkedSetBacking(T) {
 	size_t getHash(Handle sh)
 	const {
 		// NOTE: the returned hash is order independent, to avoid bogus
-		//       mismatches when comparing lists of different order
+		//	   mismatches when comparing lists of different order
 		size_t ret = 0x72d2da6c;
 		while (sh != Handle.init) {
 			ret ^= (hashOf(m_storage[sh.index].value) ^ 0xb1bdfb8d) * 0x5dbf04a4;

--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -319,7 +319,7 @@ final class URLRouter : HTTPServerRequestHandler {
 	//void setup()
 	//{
 		//auto router = new URLRouter;
-		//// Matches all GET requests for /users/groups and places
+		//// Matches all GET requests for /users/groups/* and places
 		//// the place holders in req.params as 'username' and 'groupname'.
 		//router.get("/users/:username/groups/:groupname", &addGroup);
 

--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -319,7 +319,7 @@ final class URLRouter : HTTPServerRequestHandler {
 	//void setup()
 	//{
 		//auto router = new URLRouter;
-		//// Matches all GET requests for /users[>/groups[> and places
+		//// Matches all GET requests for /users/groups and places
 		//// the place holders in req.params as 'username' and 'groupname'.
 		//router.get("/users/:username/groups/:groupname", &addGroup);
 

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -43,55 +43,55 @@ else version (Have_openssl) {}
 else version = HaveNoTLS;
 
 /**************************************************************************************************/
-/* Public functions                                                                               */
+/* Public functions																				  */
 /**************************************************************************************************/
 
 /**
-    Starts a HTTP server listening on the specified port.
+	Starts a HTTP server listening on the specified port.
 
-    request_handler will be called for each HTTP request that is made. The
-    res parameter of the callback then has to be filled with the response
-    data.
+	request_handler will be called for each HTTP request that is made. The
+	res parameter of the callback then has to be filled with the response
+	data.
 
-    request_handler can be either HTTPServerRequestDelegate/HTTPServerRequestFunction
-    or a class/struct with a member function 'handleRequest' that has the same
-    signature.
+	request_handler can be either HTTPServerRequestDelegate/HTTPServerRequestFunction
+	or a class/struct with a member function 'handleRequest' that has the same
+	signature.
 
-    Note that if the application has been started with the --disthost command line
-    switch, listenHTTP() will automatically listen on the specified VibeDist host
-    instead of locally. This allows for a seamless switch from single-host to
-    multi-host scenarios without changing the code. If you need to listen locally,
-    use listenHTTPPlain() instead.
+	Note that if the application has been started with the --disthost command line
+	switch, listenHTTP() will automatically listen on the specified VibeDist host
+	instead of locally. This allows for a seamless switch from single-host to
+	multi-host scenarios without changing the code. If you need to listen locally,
+	use listenHTTPPlain() instead.
 
-    Params:
-        settings = Customizes the HTTP servers functionality (host string or HTTPServerSettings object)
-        request_handler = This callback is invoked for each incoming request and is responsible
-            for generating the response.
+	Params:
+		settings = Customizes the HTTP servers functionality (host string or HTTPServerSettings object)
+		request_handler = This callback is invoked for each incoming request and is responsible
+			for generating the response.
 
-    Returns:
-        A handle is returned that can be used to stop listening for further HTTP
-        requests with the supplied settings. Another call to `listenHTTP` can be
-        used afterwards to start listening again.
+	Returns:
+		A handle is returned that can be used to stop listening for further HTTP
+		requests with the supplied settings. Another call to `listenHTTP` can be
+		used afterwards to start listening again.
 */
 import vibe.http.router;
 HTTPListener listenHTTP(alias Handler)(HTTPServerSettings settings = null)
-    if (is(typeof(Handler) == URLRouter) || is(typeof(Handler) : HTTPServerRequestHandler))
+	if (is(typeof(Handler) == URLRouter) || is(typeof(Handler) : HTTPServerRequestHandler))
 {
-    if (!settings)
-    	settings = new HTTPServerSettings;
+	if (!settings)
+		settings = new HTTPServerSettings;
 	return listenHTTPPlain(settings, (req, res) @trusted => Handler.handleRequest(req, res));
 }
 
 import std.traits;
 import std.typetuple;
 HTTPListener listenHTTP(alias Handler)(HTTPServerSettings settings = null)
-    if ((isCallable!Handler)
-        && is(ReturnType!Handler == void)
-        && is(ParameterTypeTuple!Handler == TypeTuple!(HTTPServerRequest, HTTPServerResponse)))
+	if ((isCallable!Handler)
+		&& is(ReturnType!Handler == void)
+		&& is(ParameterTypeTuple!Handler == TypeTuple!(HTTPServerRequest, HTTPServerResponse)))
 {
-    if (!settings)
-        settings = new HTTPServerSettings;
-    return listenHTTPPlain(settings, (req, res) @trusted => Handler(req, res));
+	if (!settings)
+		settings = new HTTPServerSettings;
+	return listenHTTPPlain(settings, (req, res) @trusted => Handler(req, res));
 }
 
 HTTPListener listenHTTP(H)(HTTPServerSettings settings, H handler)
@@ -131,171 +131,171 @@ unittest
 
 
 /**
-    Provides a HTTP request handler that responds with a static redirection to the specified URL.
+	Provides a HTTP request handler that responds with a static redirection to the specified URL.
 
-    Params:
-        url = The URL to redirect to
-        status = Redirection status to use $(LPAREN)by default this is $(D HTTPStatus.found)$(RPAREN).
+	Params:
+		url = The URL to redirect to
+		status = Redirection status to use $(LPAREN)by default this is $(D HTTPStatus.found)$(RPAREN).
 
-    Returns:
-        Returns a $(D HTTPServerRequestDelegate) that performs the redirect
+	Returns:
+		Returns a $(D HTTPServerRequestDelegate) that performs the redirect
 */
 HTTPServerRequestDelegate staticRedirect(string url, HTTPStatus status = HTTPStatus.found)
 @safe {
-    return (HTTPServerRequest req, HTTPServerResponse res){
-        res.redirect(url, status);
-    };
+	return (HTTPServerRequest req, HTTPServerResponse res){
+		res.redirect(url, status);
+	};
 }
 /// ditto
 HTTPServerRequestDelegate staticRedirect(URL url, HTTPStatus status = HTTPStatus.found)
 @safe {
-    return (HTTPServerRequest req, HTTPServerResponse res){
-        res.redirect(url, status);
-    };
+	return (HTTPServerRequest req, HTTPServerResponse res){
+		res.redirect(url, status);
+	};
 }
 
 ///
 unittest {
-    import vibe.http.router;
+	import vibe.http.router;
 
-    void test()
-    {
-        auto router = new URLRouter;
-        router.get("/old_url", staticRedirect("http://example.org/new_url", HTTPStatus.movedPermanently));
+	void test()
+	{
+		auto router = new URLRouter;
+		router.get("/old_url", staticRedirect("http://example.org/new_url", HTTPStatus.movedPermanently));
 
-        listenHTTP!router(new HTTPServerSettings);
-    }
+		listenHTTP!router(new HTTPServerSettings);
+	}
 }
 
 
 /**
-    Sets a VibeDist host to register with.
+	Sets a VibeDist host to register with.
 */
 void setVibeDistHost(string host, ushort port)
 @safe {
-    s_distHost = host;
-    s_distPort = port;
+	s_distHost = host;
+	s_distPort = port;
 }
 
 
 /**
-    Renders the given Diet template and makes all ALIASES available to the template.
+	Renders the given Diet template and makes all ALIASES available to the template.
 
-    You can call this function as a pseudo-member of `HTTPServerResponse` using
-    D's uniform function call syntax.
+	You can call this function as a pseudo-member of `HTTPServerResponse` using
+	D's uniform function call syntax.
 
-    See_also: `diet.html.compileHTMLDietFile`
+	See_also: `diet.html.compileHTMLDietFile`
 
-    Examples:
-        ---
-        string title = "Hello, World!";
-        int pageNumber = 1;
-        res.render!("mytemplate.dt", title, pageNumber);
-        ---
+	Examples:
+		---
+		string title = "Hello, World!";
+		int pageNumber = 1;
+		res.render!("mytemplate.dt", title, pageNumber);
+		---
 */
 @property void render(string template_file, ALIASES...)(HTTPServerResponse res)
 {
-    res.contentType = "text/html; charset=UTF-8";
-    version (VibeUseOldDiet)
-        pragma(msg, "VibeUseOldDiet is not supported anymore. Please undefine in the package recipe.");
-    import vibe.stream.wrapper : streamOutputRange;
-    import diet.html : compileHTMLDietFile;
-    auto output = streamOutputRange!1024(res.bodyWriter);
-    compileHTMLDietFile!(template_file, ALIASES, DefaultDietFilters)(output);
+	res.contentType = "text/html; charset=UTF-8";
+	version (VibeUseOldDiet)
+		pragma(msg, "VibeUseOldDiet is not supported anymore. Please undefine in the package recipe.");
+	import vibe.stream.wrapper : streamOutputRange;
+	import diet.html : compileHTMLDietFile;
+	auto output = streamOutputRange!1024(res.bodyWriter);
+	compileHTMLDietFile!(template_file, ALIASES, DefaultDietFilters)(output);
 }
 
 version (Have_diet_ng)
 {
-    import diet.traits;
+	import diet.traits;
 
-    /**
-        Provides the default `css`, `javascript`, `markdown` and `htmlescape` filters
-     */
-    @dietTraits
-    struct DefaultDietFilters {
-        import diet.html : HTMLOutputStyle;
-        import std.string : splitLines;
+	/**
+		Provides the default `css`, `javascript`, `markdown` and `htmlescape` filters
+	 */
+	@dietTraits
+	struct DefaultDietFilters {
+		import diet.html : HTMLOutputStyle;
+		import std.string : splitLines;
 
-        version (VibeOutputCompactHTML) enum HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.compact;
-        else enum HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.pretty;
+		version (VibeOutputCompactHTML) enum HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.compact;
+		else enum HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.pretty;
 
-        static string filterCss(I)(I text, size_t indent = 0)
-        {
-            auto lines = splitLines(text);
+		static string filterCss(I)(I text, size_t indent = 0)
+		{
+			auto lines = splitLines(text);
 
-            string indent_string = "\n";
-            while (indent-- > 0) indent_string ~= '\t';
+			string indent_string = "\n";
+			while (indent-- > 0) indent_string ~= '\t';
 
-            string ret = indent_string~"<style type=\"text/css\"><!--";
-            indent_string = indent_string ~ '\t';
-            foreach (ln; lines) ret ~= indent_string ~ ln;
-            indent_string = indent_string[0 .. $-1];
-            ret ~= indent_string ~ "--></style>";
+			string ret = indent_string~"<style type=\"text/css\"><!--";
+			indent_string = indent_string ~ '\t';
+			foreach (ln; lines) ret ~= indent_string ~ ln;
+			indent_string = indent_string[0 .. $-1];
+			ret ~= indent_string ~ "--></style>";
 
-            return ret;
-        }
+			return ret;
+		}
 
 
-        static string filterJavascript(I)(I text, size_t indent = 0)
-        {
-            auto lines = splitLines(text);
+		static string filterJavascript(I)(I text, size_t indent = 0)
+		{
+			auto lines = splitLines(text);
 
-            string indent_string = "\n";
-            while (indent-- > 0) indent_string ~= '\t';
+			string indent_string = "\n";
+			while (indent-- > 0) indent_string ~= '\t';
 
-            string ret = indent_string~"<script type=\"application/javascript\">";
-            ret ~= indent_string~'\t' ~ "//<![CDATA[";
-            foreach (ln; lines) ret ~= indent_string ~ '\t' ~ ln;
-            ret ~= indent_string ~ '\t' ~ "//]]>" ~ indent_string ~ "</script>";
+			string ret = indent_string~"<script type=\"application/javascript\">";
+			ret ~= indent_string~'\t' ~ "//<![CDATA[";
+			foreach (ln; lines) ret ~= indent_string ~ '\t' ~ ln;
+			ret ~= indent_string ~ '\t' ~ "//]]>" ~ indent_string ~ "</script>";
 
-            return ret;
-        }
+			return ret;
+		}
 
-        static string filterMarkdown(I)(I text)
-        {
-            import vibe.textfilter.markdown : markdown = filterMarkdown;
-            // TODO: indent
-            return markdown(text);
-        }
+		static string filterMarkdown(I)(I text)
+		{
+			import vibe.textfilter.markdown : markdown = filterMarkdown;
+			// TODO: indent
+			return markdown(text);
+		}
 
-        static string filterHtmlescape(I)(I text)
-        {
-            import vibe.textfilter.html : htmlEscape;
-            // TODO: indent
-            return htmlEscape(text);
-        }
+		static string filterHtmlescape(I)(I text)
+		{
+			import vibe.textfilter.html : htmlEscape;
+			// TODO: indent
+			return htmlEscape(text);
+		}
 
-        static this()
-        {
-            filters["css"] = (input, scope output) { output(filterCss(input)); };
-            filters["javascript"] = (input, scope output) { output(filterJavascript(input)); };
-            filters["markdown"] = (input, scope output) { output(filterMarkdown(() @trusted { return cast(string)input; } ())); };
-            filters["htmlescape"] = (input, scope output) { output(filterHtmlescape(input)); };
-        }
+		static this()
+		{
+			filters["css"] = (input, scope output) { output(filterCss(input)); };
+			filters["javascript"] = (input, scope output) { output(filterJavascript(input)); };
+			filters["markdown"] = (input, scope output) { output(filterMarkdown(() @trusted { return cast(string)input; } ())); };
+			filters["htmlescape"] = (input, scope output) { output(filterHtmlescape(input)); };
+		}
 
-        static SafeFilterCallback[string] filters;
-    }
+		static SafeFilterCallback[string] filters;
+	}
 
 
 	unittest {
-	    static string compile(string diet)() {
-	    	import std.array : appender;
-	    	import std.string : strip;
-	    	import diet.html : compileHTMLDietString;
-	    	auto dst = appender!string;
-	    	dst.compileHTMLDietString!(diet, DefaultDietFilters);
-	    	return strip(cast(string)(dst.data));
-	    }
+		static string compile(string diet)() {
+			import std.array : appender;
+			import std.string : strip;
+			import diet.html : compileHTMLDietString;
+			auto dst = appender!string;
+			dst.compileHTMLDietString!(diet, DefaultDietFilters);
+			return strip(cast(string)(dst.data));
+		}
 
-	    assert(compile!":css .test" == "<style type=\"text/css\"><!--\n\t.test\n--></style>");
-	    assert(compile!":javascript test();" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
-	    assert(compile!":markdown **test**" == "<p><strong>test</strong>\n</p>");
-	    assert(compile!":htmlescape <test>" == "&lt;test&gt;");
-	    assert(compile!":css !{\".test\"}" == "<style type=\"text/css\"><!--\n\t.test\n--></style>");
-	    assert(compile!":javascript !{\"test();\"}" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
-	    assert(compile!":markdown !{\"**test**\"}" == "<p><strong>test</strong>\n</p>");
-	    assert(compile!":htmlescape !{\"<test>\"}" == "&lt;test&gt;");
-	    assert(compile!":javascript\n\ttest();" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
+		assert(compile!":css .test" == "<style type=\"text/css\"><!--\n\t.test\n--></style>");
+		assert(compile!":javascript test();" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
+		assert(compile!":markdown **test**" == "<p><strong>test</strong>\n</p>");
+		assert(compile!":htmlescape <test>" == "&lt;test&gt;");
+		assert(compile!":css !{\".test\"}" == "<style type=\"text/css\"><!--\n\t.test\n--></style>");
+		assert(compile!":javascript !{\"test();\"}" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
+		assert(compile!":markdown !{\"**test**\"}" == "<p><strong>test</strong>\n</p>");
+		assert(compile!":htmlescape !{\"<test>\"}" == "&lt;test&gt;");
+		assert(compile!":javascript\n\ttest();" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
 	}
 }
 
@@ -326,8 +326,8 @@ HTTPServerRequest createTestHTTPServerRequest(URL url, HTTPMethod method, InetHe
 }
 
 /**
-      Creates a HTTPServerResponse suitable for writing unit tests.
-      */
+	  Creates a HTTPServerResponse suitable for writing unit tests.
+	  */
 HTTPServerResponse createTestHTTPServerResponse(OutputStream data_sink = null, SessionStore session_store = null)
 @safe {
 	import vibe.stream.wrapper;
@@ -345,7 +345,7 @@ HTTPServerResponse createTestHTTPServerResponse(OutputStream data_sink = null, S
 
 
 /**************************************************************************************************/
-/* Public types                                                                                   */
+/* Public types																					  */
 /**************************************************************************************************/
 
 /// Interface for class based request handlers
@@ -381,34 +381,34 @@ alias HTTPServerErrorPageHandler = void delegate(HTTPServerRequest req, HTTPServ
 
 
 private enum HTTPServerOptionImpl {
-	none                      = 0,
-	errorStackTraces          = 1<<7,
-	reusePort                 = 1<<8,
-	distribute                = 1<<9 // deprecated
+	none					  = 0,
+	errorStackTraces		  = 1<<7,
+	reusePort				  = 1<<8,
+	distribute				  = 1<<9 // deprecated
 }
 
 // TODO: Should be turned back into an enum once the deprecated symbols can be removed
 /**
-  	  Specifies optional features of the HTTP server.
+	  Specifies optional features of the HTTP server.
 
-  	  Disabling unneeded features can speed up the server or reduce its memory usage.
+	  Disabling unneeded features can speed up the server or reduce its memory usage.
 
-  	  Note that the options `parseFormBody`, `parseJsonBody` and `parseMultiPartBody`
-  	  will also drain the `HTTPServerRequest.bodyReader` stream whenever a request
-  	  body with form or JSON data is encountered.
+	  Note that the options `parseFormBody`, `parseJsonBody` and `parseMultiPartBody`
+	  will also drain the `HTTPServerRequest.bodyReader` stream whenever a request
+	  body with form or JSON data is encountered.
 */
 struct HTTPServerOption {
-	static enum none                      = HTTPServerOptionImpl.none;
+	static enum none					  = HTTPServerOptionImpl.none;
 	deprecated("This is done lazily. It will be removed in 0.9.")
-	static enum parseURL                  = none;
+	static enum parseURL				  = none;
 	deprecated("This is done lazily. It will be removed in 0.9.")
-	static enum parseQueryString          = none;
+	static enum parseQueryString		  = none;
 	deprecated("This is done lazily. It will be removed in 0.9.")
-	static enum parseFormBody             = none;
+	static enum parseFormBody			  = none;
 	deprecated("This is done lazily. It will be removed in 0.9.")
-	static enum parseJsonBody             = none;
+	static enum parseJsonBody			  = none;
 	deprecated("This is done lazily. It will be removed in 0.9.")
-	static enum parseMultiPartBody        = none;
+	static enum parseMultiPartBody		  = none;
 	/* Deprecated: Distributes request processing among worker threads
 
 		Note that this functionality assumes that the request handler
@@ -426,7 +426,7 @@ struct HTTPServerOption {
 		the same way in this scenario.
 	*/
 	deprecated("Use runWorkerTaskDist or start threads separately. It will be removed in 0.9.")
-	static enum distribute                = HTTPServerOptionImpl.distribute;
+	static enum distribute				  = HTTPServerOptionImpl.distribute;
 	/* Enables stack traces (`HTTPServerErrorInfo.debugMessage`).
 
 		Note that generating the stack traces are generally a costly
@@ -435,9 +435,9 @@ struct HTTPServerOption {
 		the application, such as function addresses, which can
 		help an attacker to abuse possible security holes.
 	*/
-	static enum errorStackTraces          = HTTPServerOptionImpl.errorStackTraces;
+	static enum errorStackTraces		  = HTTPServerOptionImpl.errorStackTraces;
 	/// Enable port reuse in `listenTCP()`
-	static enum reusePort                 = HTTPServerOptionImpl.reusePort;
+	static enum reusePort				  = HTTPServerOptionImpl.reusePort;
 
 	/* The default set of options.
 
@@ -536,14 +536,14 @@ final class HTTPServerSettings {
 	}
 
 	void handleErrorPage(HTTPServerRequest req, HTTPServerResponse res, HTTPServerErrorInfo err)
-    @safe {
-        errorPageHandler_(req, res, err);
-    }
+	@safe {
+		errorPageHandler_(req, res, err);
+	}
 
-    private HTTPServerErrorPageHandler errorPageHandler_ = null;
+	private HTTPServerErrorPageHandler errorPageHandler_ = null;
 
 	/// If set, a HTTPS server will be started instead of plain HTTP.
-    TLSContext tlsContext;
+	TLSContext tlsContext;
 
 	/// Session management is enabled if a session store instance is provided
 	SessionStore sessionStore;
@@ -700,21 +700,21 @@ enum SessionOption {
 
 
 /**
-    Represents a HTTP request as received by the server side.
+	Represents a HTTP request as received by the server side.
  */
 struct HTTPServerRequest {
-    private HTTPServerRequestData* m_data;
+	private HTTPServerRequestData* m_data;
 
-    this (HTTPServerRequestData* data)
-    @safe {
-        m_data = data;
-    }
+	this (HTTPServerRequestData* data)
+	@safe {
+		m_data = data;
+	}
 
-    this (SysTime reqtime, ushort bindPort)
-    @safe {
-        auto data = new HTTPServerRequestData(reqtime, bindPort);
-        () @trusted { m_data = data; } ();
-    }
+	this (SysTime reqtime, ushort bindPort)
+	@safe {
+		auto data = new HTTPServerRequestData(reqtime, bindPort);
+		() @trusted { m_data = data; } ();
+	}
 
 	package {
 		@property scope const(HTTPServerSettings) serverSettings()
@@ -723,137 +723,137 @@ struct HTTPServerRequest {
 		}
 	}
 
-    public {
+	public {
 		import vibe.utils.dictionarylist;
-        DictionaryList!(string, true, 8) params;
+		DictionaryList!(string, true, 8) params;
 
-        @property scope string requestURI() const @safe { return m_data.requestURI; }
+		@property scope string requestURI() const @safe { return m_data.requestURI; }
 
-        // ditto
-        @property void requestURI(string uri) @safe { m_data.requestURI = uri; }
+		// ditto
+		@property void requestURI(string uri) @safe { m_data.requestURI = uri; }
 
-        @property scope string peer() @safe { return m_data.peer; }
+		@property scope string peer() @safe { return m_data.peer; }
 
-        @property scope CookieValueMap cookies() @safe { return  m_data.cookies; }
+		@property scope CookieValueMap cookies() @safe { return	 m_data.cookies; }
 
-        @property scope FormFields query() @safe { return m_data.query; }
+		@property scope FormFields query() @safe { return m_data.query; }
 
-        @property scope Json json() @safe { return m_data.json; }
+		@property scope Json json() @safe { return m_data.json; }
 
-        @property scope FormFields form() @safe { return m_data.form; }
+		@property scope FormFields form() @safe { return m_data.form; }
 
-        @property scope FilePartFormFields files() @safe { return m_data.files; }
+		@property scope FilePartFormFields files() @safe { return m_data.files; }
 
-        @property scope SysTime timeCreated() const @safe { return m_data.timeCreated; }
+		@property scope SysTime timeCreated() const @safe { return m_data.timeCreated; }
 
-        @property scope URL fullURL() const @safe { return m_data.fullURL; }
+		@property scope URL fullURL() const @safe { return m_data.fullURL; }
 
-        @property scope string rootDir() const @safe { return m_data.rootDir; }
+		@property scope string rootDir() const @safe { return m_data.rootDir; }
 
-        @property scope string username() const @safe { return m_data.username; }
+		@property scope string username() const @safe { return m_data.username; }
 
-        // ditto
-        @property void username(string name)
-        @safe { m_data.username = name; }
+		// ditto
+		@property void username(string name)
+		@safe { m_data.username = name; }
 
-        @property scope string path() @safe { return m_data.path; }
+		@property scope string path() @safe { return m_data.path; }
 
-        @property scope InetHeaderMap headers() @safe { return m_data.headers; }
+		@property scope InetHeaderMap headers() @safe { return m_data.headers; }
 
-        @property scope bool persistent() const @safe { return m_data.persistent; }
+		@property scope bool persistent() const @safe { return m_data.persistent; }
 
-        @property scope string queryString() const @safe { return m_data.queryString; }
+		@property scope string queryString() const @safe { return m_data.queryString; }
 
-        // ditto
-        @property void queryString(string qstr)
-        @safe { m_data.queryString = qstr; }
+		// ditto
+		@property void queryString(string qstr)
+		@safe { m_data.queryString = qstr; }
 
-        @property scope string requestURL() const @safe { return m_data.requestURL; }
+		@property scope string requestURL() const @safe { return m_data.requestURL; }
 
-        @property scope HTTPVersion httpVersion() const @safe { return m_data.httpVersion; }
+		@property scope HTTPVersion httpVersion() const @safe { return m_data.httpVersion; }
 
-        // ditto
-        @property void httpVersion(HTTPVersion hver)
-        @safe { m_data.httpVersion = hver; }
+		// ditto
+		@property void httpVersion(HTTPVersion hver)
+		@safe { m_data.httpVersion = hver; }
 
-        @property scope string host() const @safe { return m_data.host; }
+		@property scope string host() const @safe { return m_data.host; }
 
-        // ditto
-        @property void host(string v) @safe { m_data.headers["Host"] = v; }
+		// ditto
+		@property void host(string v) @safe { m_data.headers["Host"] = v; }
 
-        @property scope string contentType() const @safe{ return m_data.contentType; }
+		@property scope string contentType() const @safe{ return m_data.contentType; }
 
-        // ditto
-        @property void contentType(string ct)
-        @safe { m_data.headers["Content-Type"] = ct; }
+		// ditto
+		@property void contentType(string ct)
+		@safe { m_data.headers["Content-Type"] = ct; }
 
-        @property scope string contentTypeParameters() const
-        @safe { return m_data.contentTypeParameters; }
+		@property scope string contentTypeParameters() const
+		@safe { return m_data.contentTypeParameters; }
 
-        @property scope NetworkAddress clientAddress() const
-        @safe { return m_data.clientAddress; }
+		@property scope NetworkAddress clientAddress() const
+		@safe { return m_data.clientAddress; }
 
-        // ditto
-        @property void clientAddress(NetworkAddress naddr)
-        @safe { m_data.clientAddress = naddr; }
+		// ditto
+		@property void clientAddress(NetworkAddress naddr)
+		@safe { m_data.clientAddress = naddr; }
 
-        @property scope bool tls() const @safe { return m_data.tls; }
+		@property scope bool tls() const @safe { return m_data.tls; }
 
-        // ditto
-        @property void tls(bool val)
-        @safe { m_data.tls = val; }
+		// ditto
+		@property void tls(bool val)
+		@safe { m_data.tls = val; }
 
-        @property scope HTTPMethod method() const @safe { return m_data.method; }
+		@property scope HTTPMethod method() const @safe { return m_data.method; }
 
-        // ditto
-        @property void method(HTTPMethod m) @safe { m_data.method = m; }
+		// ditto
+		@property void method(HTTPMethod m) @safe { m_data.method = m; }
 
-        @property scope HTTPServerSettings m_settings()
-        @safe { return m_data.m_settings; }
+		@property scope HTTPServerSettings m_settings()
+		@safe { return m_data.m_settings; }
 
-        // ditto
-        @property void m_settings(HTTPServerSettings settings)
-        @safe { m_data.m_settings = settings; }
+		// ditto
+		@property void m_settings(HTTPServerSettings settings)
+		@safe { m_data.m_settings = settings; }
 
 		@property scope InputStream bodyReader() @safe { return m_data.bodyReader; }
 
-        // ditto
-        @property void bodyReader(InputStream inStr)
-        @safe { m_data.bodyReader = inStr; }
+		// ditto
+		@property void bodyReader(InputStream inStr)
+		@safe { m_data.bodyReader = inStr; }
 
-        @property scope string password() const @safe{ return m_data.password; }
+		@property scope string password() const @safe{ return m_data.password; }
 
-        // ditto
-        @property void password(string pwd)
-        @safe{ m_data.password = pwd; }
+		// ditto
+		@property void password(string pwd)
+		@safe{ m_data.password = pwd; }
 
-        @property scope Session session() @safe { return m_data.session; }
+		@property scope Session session() @safe { return m_data.session; }
 
-        // ditto
-        @property void session(Session session)
-        @safe { m_data.session = session; }
+		// ditto
+		@property void session(Session session)
+		@safe { m_data.session = session; }
 
 
 		@property scope InetPath requestPath() const @safe { return m_data.requestPath; }
 
-        // ditto
+		// ditto
 		@property void requestPath(InetPath reqpath)
-        @safe { m_data.requestPath = reqpath; }
+		@safe { m_data.requestPath = reqpath; }
 
 		@property scope FilePartFormFields _files() @safe { return m_data._files; }
 
-        @property scope bool noLog() const @safe { return m_data.noLog; }
+		@property scope bool noLog() const @safe { return m_data.noLog; }
 
-        @property scope TLSCertificateInformation clientCertificate()
-        @safe {
-            return m_data.clientCertificate;
-        }
+		@property scope TLSCertificateInformation clientCertificate()
+		@safe {
+			return m_data.clientCertificate;
+		}
 
-        @property void clientCertificate(TLSCertificateInformation cert)
-        @safe {
-            m_data.clientCertificate = cert;
-        }
-    }
+		@property void clientCertificate(TLSCertificateInformation cert)
+		@safe {
+			m_data.clientCertificate = cert;
+		}
+	}
 }
 
 /**
@@ -862,12 +862,12 @@ struct HTTPServerRequest {
 struct HTTPServerResponse {
 	@safe:
 
-    private HTTPServerResponseData *m_data;
+	private HTTPServerResponseData *m_data;
 
-    this (HTTPServerResponseData *data)
-    {
-        m_data = data;
-    }
+	this (HTTPServerResponseData *data)
+	{
+		m_data = data;
+	}
 
 	static if (!is(Stream == InterfaceProxy!Stream)) {
 		this(Stream conn, ConnectionStream raw_connection, HTTPServerSettings settings, IAllocator req_alloc)
@@ -1149,7 +1149,7 @@ struct HTTPListener {
 				if (l.removeVirtualHost(vhid)) {
 					if (!l.hasVirtualHosts) {
 						l.stopListening();
-                        logInfo("Stopped to listen for HTTP%s requests on %s:%s", l.tlsContext ? "S": "", l.bindAddress, l.bindPort);
+						logInfo("Stopped to listen for HTTP%s requests on %s:%s", l.tlsContext ? "S": "", l.bindAddress, l.bindPort);
 						logInfo("Stopped to listen for HTTP%s requests on %s:%s", "", l.bindAddress, l.bindPort);
 						s_contexts = s_contexts[0 .. lidx] ~ s_contexts[lidx+1 .. $];
 					}
@@ -1162,13 +1162,13 @@ struct HTTPListener {
 
 /** Represents a single HTTP server port.
 
-    This class defines the incoming interface, port, and TLS configuration of
-    the public server port. The public server port may differ from the local
-    one if a reverse proxy of some kind is facing the public internet and
-    forwards to this HTTP server.
+	This class defines the incoming interface, port, and TLS configuration of
+	the public server port. The public server port may differ from the local
+	one if a reverse proxy of some kind is facing the public internet and
+	forwards to this HTTP server.
 
-    Multiple virtual hosts can be configured to be served from the same port.
-    Their TLS settings must be compatible and each virtual host must have a
+	Multiple virtual hosts can be configured to be served from the same port.
+	Their TLS settings must be compatible and each virtual host must have a
 */
 final class HTTPServerContext {
 	struct VirtualHost {
@@ -1183,7 +1183,7 @@ final class HTTPServerContext {
 		VirtualHost[] m_virtualHosts;
 		string m_bindAddress;
 		ushort m_bindPort;
-        TLSContext m_tlsContext;
+		TLSContext m_tlsContext;
 		static size_t s_vhostIDCounter = 1;
 	}
 
@@ -1203,7 +1203,7 @@ final class HTTPServerContext {
 		returned, which forwards to the individual contexts based on the
 		requested host name.
 	*/
-    @property TLSContext tlsContext() { return m_tlsContext; }
+	@property TLSContext tlsContext() { return m_tlsContext; }
 
 	/// The local network interface IP address associated with this listener
 	@property string bindAddress() const { return m_bindAddress; }
@@ -1214,8 +1214,8 @@ final class HTTPServerContext {
 	/// Determines if any virtual hosts have been addded
 	@property bool hasVirtualHosts() const { return m_virtualHosts.length > 0; }
 
-    /// Make m_virtualhosts visible
-    @property scope VirtualHost[] virtualHosts() { return m_virtualHosts; }
+	/// Make m_virtualhosts visible
+	@property scope VirtualHost[] virtualHosts() { return m_virtualHosts; }
 
 	/** Adds a single virtual host.
 
@@ -1241,18 +1241,18 @@ final class HTTPServerContext {
 		if (settings.accessLogFile.length)
 			vhost.loggers ~= new HTTPFileLogger(settings, settings.accessLogFormat, settings.accessLogFile);
 
-        if (!m_virtualHosts.length) m_tlsContext = settings.tlsContext;
+		if (!m_virtualHosts.length) m_tlsContext = settings.tlsContext;
 
-        enforce((m_tlsContext !is null) == (settings.tlsContext !is null),
-            "Cannot mix HTTP and HTTPS virtual hosts within the same listener.");
+		enforce((m_tlsContext !is null) == (settings.tlsContext !is null),
+			"Cannot mix HTTP and HTTPS virtual hosts within the same listener.");
 
-        if (m_tlsContext) addSNIHost(settings);
+		if (m_tlsContext) addSNIHost(settings);
 
 		m_virtualHosts ~= vhost;
 
 		if (settings.hostName.length) {
-            auto proto = settings.tlsContext ? "https" : "http";
-            auto port = settings.tlsContext && settings.port == 443 || !settings.tlsContext && settings.port == 80 ? "" : ":" ~ settings.port.to!string;
+			auto proto = settings.tlsContext ? "https" : "http";
+			auto port = settings.tlsContext && settings.port == 443 || !settings.tlsContext && settings.port == 80 ? "" : ":" ~ settings.port.to!string;
 			logInfo("Added virtual host %s://%s:%s/ (%s)", proto, settings.hostName, m_bindPort, m_bindAddress);
 		}
 
@@ -1277,37 +1277,37 @@ final class HTTPServerContext {
 		m_listener.stopListening();
 	}
 
-    private void addSNIHost(HTTPServerSettings settings)
-    {
-        if (settings.tlsContext !is m_tlsContext && m_tlsContext.kind != TLSContextKind.serverSNI) {
-            logDebug("Create SNI TLS context for %s, port %s", bindAddress, bindPort);
-            m_tlsContext = createTLSContext(TLSContextKind.serverSNI);
-            m_tlsContext.sniCallback = &onSNI;
-        }
+	private void addSNIHost(HTTPServerSettings settings)
+	{
+		if (settings.tlsContext !is m_tlsContext && m_tlsContext.kind != TLSContextKind.serverSNI) {
+			logDebug("Create SNI TLS context for %s, port %s", bindAddress, bindPort);
+			m_tlsContext = createTLSContext(TLSContextKind.serverSNI);
+			m_tlsContext.sniCallback = &onSNI;
+		}
 
-    }
+	}
 
-    private TLSContext onSNI(string servername)
-    {
-        foreach (vhost; m_virtualHosts)
-            if (vhost.settings.hostName.icmp(servername) == 0) {
-                logDebug("Found context for SNI host '%s'.", servername);
-                return vhost.settings.tlsContext;
-            }
-        logDebug("No context found for SNI host '%s'.", servername);
-        return null;
-    }
+	private TLSContext onSNI(string servername)
+	{
+		foreach (vhost; m_virtualHosts)
+			if (vhost.settings.hostName.icmp(servername) == 0) {
+				logDebug("Found context for SNI host '%s'.", servername);
+				return vhost.settings.tlsContext;
+			}
+		logDebug("No context found for SNI host '%s'.", servername);
+		return null;
+	}
 }
 
 
 /**************************************************************************************************/
-/* Private types                                                                                  */
+/* Private types																				  */
 /**************************************************************************************************/
 
 private enum MaxHTTPHeaderLineLength = 4096;
 
 /**************************************************************************************************/
-/* Private functions                                                                              */
+/* Private functions																			  */
 /**************************************************************************************************/
 
 private {
@@ -1363,7 +1363,7 @@ private HTTPListener listenHTTPPlain(HTTPServerSettings settings, HTTPServerRequ
 			if (listen_info.bindPort == 0)
 				listen_info.m_bindPort = ret.bindAddress.port;
 
-            auto proto = listen_info.tlsContext ? "https" : "http";
+			auto proto = listen_info.tlsContext ? "https" : "http";
 			auto urladdr = listen_info.bindAddress;
 			if (urladdr.canFind(':')) urladdr = "["~urladdr~"]";
 			logInfo("Listening for requests on %s://%s:%s/", proto, urladdr, listen_info.bindPort);
@@ -1402,57 +1402,57 @@ private HTTPListener listenHTTPPlain(HTTPServerSettings settings, HTTPServerRequ
 }
 
 unittest{
-    // testing a class that implements HTTPServerRequestHandler
+	// testing a class that implements HTTPServerRequestHandler
 
-    class MyReqHandler : HTTPServerRequestHandler
-    {
-        override void handleRequest(HTTPServerRequest req, HTTPServerResponse res)
-        @safe {
-            if (req.path == "/")
-            res.writeBody("Hello, World! Interface");
-        }
-    }
+	class MyReqHandler : HTTPServerRequestHandler
+	{
+		override void handleRequest(HTTPServerRequest req, HTTPServerResponse res)
+		@safe {
+			if (req.path == "/")
+			res.writeBody("Hello, World! Interface");
+		}
+	}
 
 	auto settings = new HTTPServerSettings();
 	settings.port = 8050;
 	settings.bindAddresses = ["localhost"];
 
-    MyReqHandler mrh = new MyReqHandler;
+	MyReqHandler mrh = new MyReqHandler;
 
-    listenHTTP!mrh(settings);
+	listenHTTP!mrh(settings);
 }
 
 unittest {
-    // testing a callable as request handler
-    void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
-    @safe {
-        if (req.path == "/")
-        res.writeBody("Hello, World! Delegate");
-    }
+	// testing a callable as request handler
+	void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
+	@safe {
+		if (req.path == "/")
+		res.writeBody("Hello, World! Delegate");
+	}
 
 	auto settings = new HTTPServerSettings();
 	settings.port = 8060;
 	settings.bindAddresses = ["localhost"];
 
-    listenHTTP!handleRequest(settings);
+	listenHTTP!handleRequest(settings);
 }
 
 unittest {
-    // testing HTTPS connections
-    void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
-    @safe {
-        if (req.path == "/")
-        res.writeBody("Hello, World! Delegate");
-    }
+	// testing HTTPS connections
+	void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
+	@safe {
+		if (req.path == "/")
+		res.writeBody("Hello, World! Delegate");
+	}
 
-    auto settings = new HTTPServerSettings();
-    settings.port = 8070;
-    settings.bindAddresses = ["localhost"];
-    settings.tlsContext = createTLSContext(TLSContextKind.server);
-    settings.tlsContext.useCertificateChainFile("test/dummy-server-cert.pem");
-    settings.tlsContext.usePrivateKeyFile("test/dummy-server-key.pem");
+	auto settings = new HTTPServerSettings();
+	settings.port = 8070;
+	settings.bindAddresses = ["localhost"];
+	settings.tlsContext = createTLSContext(TLSContextKind.server);
+	settings.tlsContext.useCertificateChainFile("test/dummy-server-cert.pem");
+	settings.tlsContext.usePrivateKeyFile("test/dummy-server-key.pem");
 
-    listenHTTP!handleRequest(settings);
+	listenHTTP!handleRequest(settings);
 }
 
 //// NOTE: just a possible idea for the low level api
@@ -1536,7 +1536,7 @@ struct HTTPServerRequestData {
 			Remarks: This field is only set if `tls` is true, and the peer
 			presented a client certificate.
 		*/
-        TLSCertificateInformation clientCertificate;
+		TLSCertificateInformation clientCertificate;
 
 		/* Deprecated: The _path part of the URL.
 
@@ -1820,7 +1820,7 @@ struct HTTPServerRequestData {
 			if (url.schema == "https") {
 				if (m_port != 443U) url.port = m_port;
 			} else {
-				if (m_port != 80U)  url.port = m_port;
+				if (m_port != 80U)	url.port = m_port;
 			}
 		}
 
@@ -1998,12 +1998,12 @@ struct HTTPServerResponseData {
 
 		/** Writes the whole response body at once, without doing any further encoding.
 
-		  	  The caller has to make sure that the appropriate headers are set correctly
-		  	  (i.e. Content-Type and Content-Encoding).
+			  The caller has to make sure that the appropriate headers are set correctly
+			  (i.e. Content-Type and Content-Encoding).
 
-		  	  Note that the version taking a RandomAccessStream may perform additional
-		  	  optimizations such as sending a file directly from the disk to the
-		  	  network card using a DMA transfer.
+			  Note that the version taking a RandomAccessStream may perform additional
+			  optimizations such as sending a file directly from the disk to the
+			  network card using a DMA transfer.
 
 		 */
 		void writeRawBody(RandomAccessStream)(RandomAccessStream stream) @safe
@@ -2105,12 +2105,12 @@ struct HTTPServerResponseData {
 		}
 
 		/**
-	 	 * Writes the response with no body.
-	 	 *
-	 	 * This method should be used in situations where no body is
-	 	 * requested, such as a HEAD request. For an empty body, just use writeBody,
-	 	 * as this method causes problems with some keep-alive connections.
-	 	 */
+		 * Writes the response with no body.
+		 *
+		 * This method should be used in situations where no body is
+		 * requested, such as a HEAD request. For an empty body, just use writeBody,
+		 * as this method causes problems with some keep-alive connections.
+		 */
 		void writeVoidBody()
 			@safe {
 				if (!m_isHeadResponse) {
@@ -2124,8 +2124,8 @@ struct HTTPServerResponseData {
 
 		/** A stream for writing the body of the HTTP response.
 
-		  	  Note that after 'bodyWriter' has been accessed for the first time, it
-		  	  is not allowed to change any header or the status code of the response.
+			  Note that after 'bodyWriter' has been accessed for the first time, it
+			  is not allowed to change any header or the status code of the response.
 		 */
 		@property InterfaceProxy!OutputStream bodyWriter()
 			@safe {
@@ -2478,7 +2478,7 @@ private void parseCookies(string str, ref CookieValueMap cookies)
 unittest
 {
 	  auto cvm = CookieValueMap();
-	  parseCookies("foo=bar;; baz=zinga; öö=üü   ;   møøse=was=sacked;    onlyval1; =onlyval2; onlykey=", cvm);
+	  parseCookies("foo=bar;; baz=zinga; öö=üü	 ;	 møøse=was=sacked;	onlyval1; =onlyval2; onlykey=", cvm);
 	  assert(cvm["foo"] == "bar");
 	  assert(cvm["baz"] == "zinga");
 	  assert(cvm["öö"] == "üü");
@@ -2501,7 +2501,7 @@ void parseRequestHeader(InputStream)(HTTPServerRequest reqStruct, InputStream ht
 	if (isInputStream!InputStream)
 {
 	auto stream = FreeListRef!LimitedHTTPInputStream(http_stream, max_header_size);
-    auto req = reqStruct.m_data;
+	auto req = reqStruct.m_data;
 
 	logTrace("HTTP server reading status line");
 	auto reqln = () @trusted { return cast(string)stream.readLine(MaxHTTPHeaderLineLength, "\r\n", alloc); }();
@@ -2536,9 +2536,9 @@ void parseRequestHeader(InputStream)(HTTPServerRequest reqStruct, InputStream ht
 
 string formatRFC822DateAlloc(IAllocator alloc, SysTime time)
 @safe {
-    auto app = AllocAppender!string(alloc);
-    writeRFC822DateTimeString(app, time);
-    return () @trusted { return app.data; } ();
+	auto app = AllocAppender!string(alloc);
+	writeRFC822DateTimeString(app, time);
+	return () @trusted { return app.data; } ();
 }
 
 version (VibeDebugCatchAll) alias UncaughtException = Throwable;

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1,44 +1,1309 @@
 module vibe.http.server;
 
-import vibe.core.net;
+public import vibe.core.net;
 import vibe.core.stream;
 import vibe.http.internal.http1;
 import vibe.http.internal.http2;
 
+public import vibe.http.log;
+public import vibe.http.common;
+public import vibe.http.session;
+import vibe.inet.message;
+import vibe.core.file;
+import vibe.core.log;
+import vibe.inet.url;
+import vibe.inet.webform;
+import vibe.data.json;
+import vibe.internal.allocator;
+import vibe.internal.freelistref;
+import vibe.internal.interfaceproxy : InterfaceProxy;
+import vibe.stream.wrapper : ConnectionProxyStream, createConnectionProxyStream, createConnectionProxyStreamFL;
+import vibe.stream.tls;
+import vibe.utils.array;
+import vibe.utils.string;
+import vibe.stream.counting;
+import vibe.stream.operations;
+import vibe.stream.zlib;
+import vibe.textfilter.urlencode : urlEncode, urlDecode;
 
+import std.datetime;
+import std.typecons;
+import std.conv;
+import std.array;
+import std.algorithm;
+import std.format;
+import std.parallelism;
+import std.exception;
+import std.string;
+import std.encoding : sanitize;
+
+version (VibeNoSSL) version = HaveNoTLS;
+else version (Have_botan) {}
+else version (Have_openssl) {}
+else version = HaveNoTLS;
+
+/**************************************************************************************************/
+/* Public functions                                                                               */
+/**************************************************************************************************/
+
+/**
+    Starts a HTTP server listening on the specified port.
+
+    request_handler will be called for each HTTP request that is made. The
+    res parameter of the callback then has to be filled with the response
+    data.
+
+    request_handler can be either HTTPServerRequestDelegate/HTTPServerRequestFunction
+    or a class/struct with a member function 'handleRequest' that has the same
+    signature.
+
+    Note that if the application has been started with the --disthost command line
+    switch, listenHTTP() will automatically listen on the specified VibeDist host
+    instead of locally. This allows for a seamless switch from single-host to
+    multi-host scenarios without changing the code. If you need to listen locally,
+    use listenHTTPPlain() instead.
+
+    Params:
+        settings = Customizes the HTTP servers functionality (host string or HTTPServerSettings object)
+        request_handler = This callback is invoked for each incoming request and is responsible
+            for generating the response.
+
+    Returns:
+        A handle is returned that can be used to stop listening for further HTTP
+        requests with the supplied settings. Another call to `listenHTTP` can be
+        used afterwards to start listening again.
+*/
+import vibe.http.router;
 HTTPListener listenHTTP(alias Handler)(HTTPServerSettings settings = null)
+    if (is(typeof(Handler) == URLRouter) || is(typeof(Handler) : HTTPServerRequestHandler))
 {
-
+    if (!settings)
+    	settings = new HTTPServerSettings;
+	return listenHTTPPlain(settings, (req, res) @trusted => Handler.handleRequest(req, res));
 }
 
-void handleIncomingHTTPConnection(ConnectionStream connection, in ref NetworkAddress local_address)
+import std.traits;
+import std.typetuple;
+HTTPListener listenHTTP(alias Handler)(HTTPServerSettings settings = null)
+    if ((isCallable!Handler)
+        && is(ReturnType!Handler == void)
+        && is(ParameterTypeTuple!Handler == TypeTuple!(HTTPServerRequest, HTTPServerResponse)))
 {
-	auto context = getDefaultHTTPContext(local_address);
-
+    if (!settings)
+        settings = new HTTPServerSettings;
+    return listenHTTPPlain(settings, (req, res) @trusted => Handler(req, res));
 }
 
-void handleIncomingHTTPRequest(ConnectionStream)(ConnectionStream connection)
+//unittest
+//{
+    //void test()
+    //{
+        //static void testSafeFunction(HTTPServerRequest req, HTTPServerResponse res) @safe {}
+        //listenHTTP("0.0.0.0:8080", &testSafeFunction);
+        //listenHTTP(":8080", new class HTTPServerRequestHandler {
+            //void handleRequest(HTTPServerRequest req, HTTPServerResponse res) @safe {}
+        //});
+        //listenHTTP(":8080", (req, res) {});
+
+        //static void testSafeFunctionS(scope HTTPServerRequest req, scope HTTPServerResponse res) @safe {}
+        //listenHTTP(":8080", &testSafeFunctionS);
+        //void testSafeDelegateS(scope HTTPServerRequest req, scope HTTPServerResponse res) @safe {}
+        //listenHTTP(":8080", &testSafeDelegateS);
+        //listenHTTP(":8080", new class HTTPServerRequestHandler {
+            //void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res) @safe {}
+        //});
+        //listenHTTP(":8080", (scope req, scope res) {});
+    //}
+//}
+
+
+/**
+    Provides a HTTP request handler that responds with a static redirection to the specified URL.
+
+    Params:
+        url = The URL to redirect to
+        status = Redirection status to use $(LPAREN)by default this is $(D HTTPStatus.found)$(RPAREN).
+
+    Returns:
+        Returns a $(D HTTPServerRequestDelegate) that performs the redirect
+*/
+HTTPServerRequestDelegate staticRedirect(string url, HTTPStatus status = HTTPStatus.found)
+@safe {
+    return (HTTPServerRequest req, HTTPServerResponse res){
+        res.redirect(url, status);
+    };
+}
+/// ditto
+HTTPServerRequestDelegate staticRedirect(URL url, HTTPStatus status = HTTPStatus.found)
+@safe {
+    return (HTTPServerRequest req, HTTPServerResponse res){
+        res.redirect(url, status);
+    };
+}
+
+///
+unittest {
+    import vibe.http.router;
+
+    void test()
+    {
+        auto router = new URLRouter;
+        router.get("/old_url", staticRedirect("http://example.org/new_url", HTTPStatus.movedPermanently));
+
+        listenHTTP!router(new HTTPServerSettings);
+    }
+}
+
+
+/**
+    Sets a VibeDist host to register with.
+*/
+void setVibeDistHost(string host, ushort port)
+@safe {
+    s_distHost = host;
+    s_distPort = port;
+}
+
+
+/**
+    Renders the given Diet template and makes all ALIASES available to the template.
+
+    You can call this function as a pseudo-member of `HTTPServerResponse` using
+    D's uniform function call syntax.
+
+    See_also: `diet.html.compileHTMLDietFile`
+
+    Examples:
+        ---
+        string title = "Hello, World!";
+        int pageNumber = 1;
+        res.render!("mytemplate.dt", title, pageNumber);
+        ---
+*/
+@property void render(string template_file, ALIASES...)(HTTPServerResponse res)
 {
-
+    res.contentType = "text/html; charset=UTF-8";
+    version (VibeUseOldDiet)
+        pragma(msg, "VibeUseOldDiet is not supported anymore. Please undefine in the package recipe.");
+    import vibe.stream.wrapper : streamOutputRange;
+    import diet.html : compileHTMLDietFile;
+    auto output = streamOutputRange!1024(res.bodyWriter);
+    compileHTMLDietFile!(template_file, ALIASES, DefaultDietFilters)(output);
 }
 
-struct HTTPContext {
-	void delegate(in ref HTTPRequestHandler request) handler;
+version (Have_diet_ng)
+{
+    import diet.traits;
+
+    /**
+        Provides the default `css`, `javascript`, `markdown` and `htmlescape` filters
+     */
+    @dietTraits
+    struct DefaultDietFilters {
+        import diet.html : HTMLOutputStyle;
+        import std.string : splitLines;
+
+        version (VibeOutputCompactHTML) enum HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.compact;
+        else enum HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.pretty;
+
+        static string filterCss(I)(I text, size_t indent = 0)
+        {
+            auto lines = splitLines(text);
+
+            string indent_string = "\n";
+            while (indent-- > 0) indent_string ~= '\t';
+
+            string ret = indent_string~"<style type=\"text/css\"><!--";
+            indent_string = indent_string ~ '\t';
+            foreach (ln; lines) ret ~= indent_string ~ ln;
+            indent_string = indent_string[0 .. $-1];
+            ret ~= indent_string ~ "--></style>";
+
+            return ret;
+        }
+
+
+        static string filterJavascript(I)(I text, size_t indent = 0)
+        {
+            auto lines = splitLines(text);
+
+            string indent_string = "\n";
+            while (indent-- > 0) indent_string ~= '\t';
+
+            string ret = indent_string~"<script type=\"application/javascript\">";
+            ret ~= indent_string~'\t' ~ "//<![CDATA[";
+            foreach (ln; lines) ret ~= indent_string ~ '\t' ~ ln;
+            ret ~= indent_string ~ '\t' ~ "//]]>" ~ indent_string ~ "</script>";
+
+            return ret;
+        }
+
+        static string filterMarkdown(I)(I text)
+        {
+            import vibe.textfilter.markdown : markdown = filterMarkdown;
+            // TODO: indent
+            return markdown(text);
+        }
+
+        static string filterHtmlescape(I)(I text)
+        {
+            import vibe.textfilter.html : htmlEscape;
+            // TODO: indent
+            return htmlEscape(text);
+        }
+
+        static this()
+        {
+            filters["css"] = (input, scope output) { output(filterCss(input)); };
+            filters["javascript"] = (input, scope output) { output(filterJavascript(input)); };
+            filters["markdown"] = (input, scope output) { output(filterMarkdown(() @trusted { return cast(string)input; } ())); };
+            filters["htmlescape"] = (input, scope output) { output(filterHtmlescape(input)); };
+        }
+
+        static SafeFilterCallback[string] filters;
+    }
+
+
+	unittest {
+	    static string compile(string diet)() {
+	    	import std.array : appender;
+	    	import std.string : strip;
+	    	import diet.html : compileHTMLDietString;
+	    	auto dst = appender!string;
+	    	dst.compileHTMLDietString!(diet, DefaultDietFilters);
+	    	return strip(cast(string)(dst.data));
+	    }
+
+	    assert(compile!":css .test" == "<style type=\"text/css\"><!--\n\t.test\n--></style>");
+	    assert(compile!":javascript test();" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
+	    assert(compile!":markdown **test**" == "<p><strong>test</strong>\n</p>");
+	    assert(compile!":htmlescape <test>" == "&lt;test&gt;");
+	    assert(compile!":css !{\".test\"}" == "<style type=\"text/css\"><!--\n\t.test\n--></style>");
+	    assert(compile!":javascript !{\"test();\"}" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
+	    assert(compile!":markdown !{\"**test**\"}" == "<p><strong>test</strong>\n</p>");
+	    assert(compile!":htmlescape !{\"<test>\"}" == "&lt;test&gt;");
+	    assert(compile!":javascript\n\ttest();" == "<script type=\"application/javascript\">\n\t//<![CDATA[\n\ttest();\n\t//]]>\n</script>");
+	}
 }
 
-// NOTE: just a possible idea for the low level api
-struct HTTPRequestHandler {
-	void read(alias HeaderCallback, alias BodyCallback)()
-	{
-		connection.readHeaders!HeaderCallback();
-		connection.readBody!BodyCallback();
+
+/**
+  Creates a HTTPServerRequest suitable for writing unit tests.
+ */
+HTTPServerRequest createTestHTTPServerRequest(URL url, HTTPMethod method = HTTPMethod.GET, InputStream data = null)
+@safe {
+	InetHeaderMap headers;
+	return createTestHTTPServerRequest(url, method, headers, data);
+}
+/// ditto
+HTTPServerRequest createTestHTTPServerRequest(URL url, HTTPMethod method, InetHeaderMap headers, InputStream data = null)
+@safe {
+	auto tls = url.schema == "https";
+	auto ret = HTTPServerRequest(Clock.currTime(UTC()), url.port ? url.port : tls ? 443 : 80);
+	ret.requestPath = url.path;
+	ret.queryString = url.queryString;
+	ret.username = url.username;
+	ret.password = url.password;
+	ret.requestURI = url.localURI;
+	ret.method = method;
+	ret.tls = tls;
+	//ret.headers = headers; // TODO compiler error
+	ret.bodyReader = data;
+	return ret;
+}
+
+/**
+      Creates a HTTPServerResponse suitable for writing unit tests.
+      */
+HTTPServerResponse createTestHTTPServerResponse(OutputStream data_sink = null, SessionStore session_store = null)
+@safe {
+	import vibe.stream.wrapper;
+
+	HTTPServerSettings settings;
+	if (session_store) {
+		settings = new HTTPServerSettings;
+		settings.sessionStore = session_store;
+	}
+	if (!data_sink) data_sink = new NullOutputStream;
+	auto stream = createProxyStream(Stream.init, data_sink);
+	auto ret = HTTPServerResponse(stream, null, settings, () @trusted { return vibeThreadAllocator(); } ());
+	return ret;
+}
+
+
+/**************************************************************************************************/
+/* Public types                                                                                   */
+/**************************************************************************************************/
+
+/// Interface for class based request handlers
+interface HTTPServerRequestHandler {
+	/// Handles incoming HTTP requests
+	void handleRequest(HTTPServerRequest req, HTTPServerResponse res) @safe ;
+}
+
+
+alias HTTPContext = HTTPServerContext;
+
+/// Delegate based request handler
+alias HTTPServerRequestDelegate = void delegate(HTTPServerRequest req, HTTPServerResponse res) @safe;
+/// Static function based request handler
+alias HTTPServerRequestFunction = void function(HTTPServerRequest req, HTTPServerResponse res) @safe;
+
+
+/// Aggregates all information about an HTTP error status.
+final class HTTPServerErrorInfo {
+	/// The HTTP status code
+	int code;
+	/// The error message
+	string message;
+	/// Extended error message with debug information such as a stack trace
+	string debugMessage;
+	/// The error exception, if any
+	Throwable exception;
+}
+
+
+/// Delegate type used for user defined error page generator callbacks.
+alias HTTPServerErrorPageHandler = void delegate(HTTPServerRequest req, HTTPServerResponse res, HTTPServerErrorInfo error) @safe;
+
+
+private enum HTTPServerOptionImpl {
+	none                      = 0,
+	errorStackTraces          = 1<<7,
+	reusePort                 = 1<<8,
+	distribute                = 1<<9 // deprecated
+}
+
+// TODO: Should be turned back into an enum once the deprecated symbols can be removed
+/**
+  	  Specifies optional features of the HTTP server.
+
+  	  Disabling unneeded features can speed up the server or reduce its memory usage.
+
+  	  Note that the options `parseFormBody`, `parseJsonBody` and `parseMultiPartBody`
+  	  will also drain the `HTTPServerRequest.bodyReader` stream whenever a request
+  	  body with form or JSON data is encountered.
+*/
+struct HTTPServerOption {
+	static enum none                      = HTTPServerOptionImpl.none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum parseURL                  = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum parseQueryString          = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum parseFormBody             = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum parseJsonBody             = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum parseMultiPartBody        = none;
+	/* Deprecated: Distributes request processing among worker threads
+
+		Note that this functionality assumes that the request handler
+		is implemented in a thread-safe way. However, the D type system
+		is bypassed, so that no static verification takes place.
+
+		For this reason, it is recommended to instead use
+		`vibe.core.core.runWorkerTaskDist` and call `listenHTTP`
+		from each task/thread individually. If the `reusePort` option
+		is set, then all threads will be able to listen on the same port,
+		with the operating system distributing the incoming connections.
+
+		If possible, instead of threads, the use of separate processes
+		is more robust and often faster. The `reusePort` option works
+		the same way in this scenario.
+	*/
+	deprecated("Use runWorkerTaskDist or start threads separately. It will be removed in 0.9.")
+	static enum distribute                = HTTPServerOptionImpl.distribute;
+	/* Enables stack traces (`HTTPServerErrorInfo.debugMessage`).
+
+		Note that generating the stack traces are generally a costly
+		operation that should usually be avoided in production
+		environments. It can also reveal internal information about
+		the application, such as function addresses, which can
+		help an attacker to abuse possible security holes.
+	*/
+	static enum errorStackTraces          = HTTPServerOptionImpl.errorStackTraces;
+	/// Enable port reuse in `listenTCP()`
+	static enum reusePort                 = HTTPServerOptionImpl.reusePort;
+
+	/* The default set of options.
+
+		Includes all parsing options, as well as the `errorStackTraces`
+		option if the code is compiled in debug mode.
+	*/
+	static enum defaults = () { debug return HTTPServerOptionImpl.errorStackTraces; else return HTTPServerOptionImpl.none; } ().HTTPServerOption;
+
+	deprecated("None has been renamed to none.")
+	static enum None = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum ParseURL = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum ParseQueryString = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum ParseFormBody = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum ParseJsonBody = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum ParseMultiPartBody = none;
+	deprecated("This is done lazily. It will be removed in 0.9.")
+	static enum ParseCookies = none;
+
+	HTTPServerOptionImpl x;
+	alias x this;
+}
+
+
+/**
+	Contains all settings for configuring a basic HTTP server.
+
+	The defaults are sufficient for most normal uses.
+*/
+final class HTTPServerSettings {
+	/** The port on which the HTTP server is listening.
+
+		The default value is 80. If you are running a TLS enabled server you may want to set this
+		to 443 instead.
+
+		Using a value of `0` instructs the server to use any available port on
+		the given `bindAddresses` the actual addresses and ports can then be
+		queried with `TCPListener.bindAddresses`.
+	*/
+	ushort port = 80;
+
+	/** The interfaces on which the HTTP server is listening.
+
+		By default, the server will listen on all IPv4 and IPv6 interfaces.
+	*/
+	string[] bindAddresses = ["::", "0.0.0.0"];
+
+	/** Determines the server host name.
+
+		If multiple servers are listening on the same port, the host name will determine which one
+		gets a request.
+	*/
+	string hostName;
+
+	/** Configures optional features of the HTTP server
+
+		Disabling unneeded features can improve performance or reduce the server
+		load in case of invalid or unwanted requests (DoS). By default,
+		HTTPServerOption.defaults is used.
+	*/
+	HTTPServerOptionImpl options = HTTPServerOption.defaults;
+
+	/** Time of a request after which the connection is closed with an error; not supported yet
+
+		The default limit of 0 means that the request time is not limited.
+	*/
+	Duration maxRequestTime = 0.seconds;
+
+	/** Maximum time between two request on a keep-alive connection
+
+		The default value is 10 seconds.
+	*/
+	Duration keepAliveTimeout = 10.seconds;
+
+	/// Maximum number of transferred bytes per request after which the connection is closed with
+	/// an error
+	ulong maxRequestSize = 2097152;
+
+
+	///	Maximum number of transferred bytes for the request header. This includes the request line
+	/// the url and all headers.
+	ulong maxRequestHeaderSize = 8192;
+
+	/// Sets a custom handler for displaying error pages for HTTP errors
+	@property HTTPServerErrorPageHandler errorPageHandler() @safe { return errorPageHandler_; }
+	/// ditto
+	@property void errorPageHandler(HTTPServerErrorPageHandler del) @safe { errorPageHandler_ = del; }
+	/// Scheduled for deprecation - use a `@safe` callback instead.
+	@property void errorPageHandler(void delegate(HTTPServerRequest, HTTPServerResponse, HTTPServerErrorInfo) @system del)
+	@system {
+		this.errorPageHandler = (req, res, err) @trusted { del(req, res, err); };
 	}
 
-	void write(alias HeaderCallback, alias BodyCallback)()
-	{
-		connection.writeHeaders!HeaderCallback();
-		connection.writeBody!BodyCallback();
+	void handleErrorPage(HTTPServerRequest req, HTTPServerResponse res, HTTPServerErrorInfo err) 
+    @safe {
+        errorPageHandler_(req, res, err);
+    }
+
+    private HTTPServerErrorPageHandler errorPageHandler_ = null;
+
+	/// If set, a HTTPS server will be started instead of plain HTTP.
+    TLSContext tlsContext;
+
+	/// Session management is enabled if a session store instance is provided
+	SessionStore sessionStore;
+	string sessionIdCookie = "vibe.session_id";
+
+	///
+	import vibe.core.core : vibeVersionString;
+	string serverString = "vibe.d/" ~ vibeVersionString;
+
+	/** Specifies the format used for the access log.
+
+		The log format is given using the Apache server syntax. By default NCSA combined is used.
+
+		---
+		"%h - %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\""
+		---
+	*/
+	string accessLogFormat = "%h - %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\"";
+
+	/// Spefifies the name of a file to which access log messages are appended.
+	string accessLogFile = "";
+
+	/// If set, access log entries will be output to the console.
+	bool accessLogToConsole = false;
+
+	/** Specifies a custom access logger instance.
+	*/
+	HTTPLogger accessLogger;
+
+	/// Returns a duplicate of the settings object.
+	@property HTTPServerSettings dup()
+	@safe {
+		auto ret = new HTTPServerSettings;
+		foreach (mem; __traits(allMembers, HTTPServerSettings)) {
+			static if (mem == "sslContext") {}
+			else static if (mem == "bindAddresses") ret.bindAddresses = bindAddresses.dup;
+			else static if (__traits(compiles, __traits(getMember, ret, mem) = __traits(getMember, this, mem)))
+				__traits(getMember, ret, mem) = __traits(getMember, this, mem);
+		}
+		return ret;
 	}
+
+	/// Disable support for VibeDist and instead start listening immediately.
+	bool disableDistHost = false;
+
+	/** Responds to "Accept-Encoding" by using compression if possible.
+
+		Compression can also be manually enabled by setting the
+		"Content-Encoding" header of the HTTP response appropriately before
+		sending the response body.
+
+		This setting is disabled by default. Also note that there are still some
+		known issues with the GZIP compression code.
+	*/
+	bool useCompressionIfPossible = false;
+
+
+	/** Interval between WebSocket ping frames.
+
+		The default value is 60 seconds; set to Duration.zero to disable pings.
+	*/
+	Duration webSocketPingInterval = 60.seconds;
+
+	/** Constructs a new settings object with default values.
+	*/
+	this() @safe {}
+
+	/** Constructs a new settings object with a custom bind interface and/or port.
+
+		The syntax of `bind_string` is `[<IP address>][:<port>]`, where either of
+		the two parts can be left off. IPv6 addresses must be enclosed in square
+		brackets, as they would within a URL.
+
+		Throws:
+			An exception is thrown if `bind_string` is malformed.
+	*/
+	this(string bind_string)
+	@safe {
+		this();
+
+		if (bind_string.startsWith('[')) {
+			auto idx = bind_string.indexOf(']');
+			enforce(idx > 0, "Missing closing bracket for IPv6 address.");
+			bindAddresses = [bind_string[1 .. idx]];
+			bind_string = bind_string[idx+1 .. $];
+
+			enforce(bind_string.length == 0 || bind_string.startsWith(':'),
+				"Only a colon may follow the IPv6 address.");
+		}
+
+		auto idx = bind_string.indexOf(':');
+		if (idx < 0) {
+			if (bind_string.length > 0) bindAddresses = [bind_string];
+		} else {
+			if (idx > 0) bindAddresses = [bind_string[0 .. idx]];
+			port = bind_string[idx+1 .. $].to!ushort;
+		}
+	}
+
+	///
+	unittest {
+		auto s = new HTTPServerSettings(":8080");
+		assert(s.bindAddresses == ["::", "0.0.0.0"]); // default bind addresses
+		assert(s.port == 8080);
+
+		s = new HTTPServerSettings("123.123.123.123");
+		assert(s.bindAddresses == ["123.123.123.123"]);
+		assert(s.port == 80);
+
+		s = new HTTPServerSettings("[::1]:443");
+		assert(s.bindAddresses == ["::1"]);
+		assert(s.port == 443);
+	}
+}
+
+
+/*
+	Options altering how sessions are created.
+
+	Multiple values can be or'ed together.
+
+	See_Also: HTTPServerResponse.startSession
+*/
+enum SessionOption {
+	/// No options.
+	none = 0,
+
+	/* Instructs the browser to disallow accessing the session ID from JavaScript.
+
+		See_Also: Cookie.httpOnly
+	*/
+	httpOnly = 1<<0,
+
+	/* Instructs the browser to disallow sending the session ID over
+		unencrypted connections.
+
+		By default, the type of the connection on which the session is started
+		will be used to determine if secure or noSecure is used.
+
+		See_Also: noSecure, Cookie.secure
+	*/
+	secure = 1<<1,
+
+	/* Instructs the browser to allow sending the session ID over unencrypted
+		connections.
+
+		By default, the type of the connection on which the session is started
+		will be used to determine if secure or noSecure is used.
+
+		See_Also: secure, Cookie.secure
+	*/
+	noSecure = 1<<2
+}
+
+
+/**
+    Represents a HTTP request as received by the server side.
+ */
+struct HTTPServerRequest {
+    private HTTPServerRequestData* m_data;
+
+    this (HTTPServerRequestData* data)
+    @safe {
+        m_data = data;
+    }
+
+    this (SysTime reqtime, ushort bindPort)
+    @safe {
+        auto data = new HTTPServerRequestData(reqtime, bindPort);
+        () @trusted { m_data = data; } ();
+    }
+
+	package {
+		@property scope const(HTTPServerSettings) serverSettings()
+		@safe {
+			return m_data.serverSettings;
+		}
+	}
+
+    public {
+		import vibe.utils.dictionarylist;
+        DictionaryList!(string, true, 8) params;
+
+        @property scope string requestURI() const @safe { return m_data.requestURI; }
+
+        // ditto
+        @property void requestURI(string uri) @safe { m_data.requestURI = uri; }
+
+        @property scope string peer() @safe { return m_data.peer; }
+
+        @property scope CookieValueMap cookies() @safe { return  m_data.cookies; }
+
+        @property scope FormFields query() @safe { return m_data.query; }
+
+        @property scope Json json() @safe { return m_data.json; }
+
+        @property scope FormFields form() @safe { return m_data.form; }
+
+        @property scope FilePartFormFields files() @safe { return m_data.files; }
+
+        @property scope SysTime timeCreated() const @safe { return m_data.timeCreated; }
+
+        @property scope URL fullURL() const @safe { return m_data.fullURL; }
+
+        @property scope string rootDir() const @safe { return m_data.rootDir; }
+
+        @property scope string username() const @safe { return m_data.username; }
+
+        // ditto
+        @property void username(string name)
+        @safe { m_data.username = name; }
+
+        @property scope string path() @safe { return m_data.path; }
+
+        @property scope InetHeaderMap headers() @safe { return m_data.headers; }
+
+        @property scope bool persistent() const @safe { return m_data.persistent; }
+
+        @property scope string queryString() const @safe { return m_data.queryString; }
+
+        // ditto
+        @property void queryString(string qstr)
+        @safe { m_data.queryString = qstr; }
+
+        @property scope string requestURL() const @safe { return m_data.requestURL; }
+
+        @property scope HTTPVersion httpVersion() const @safe { return m_data.httpVersion; }
+
+        // ditto
+        @property void httpVersion(HTTPVersion hver)
+        @safe { m_data.httpVersion = hver; }
+
+        @property scope string host() const @safe { return m_data.host; }
+
+        // ditto
+        @property void host(string v) @safe { m_data.headers["Host"] = v; }
+
+        @property scope string contentType() const @safe{ return m_data.contentType; }
+
+        // ditto
+        @property void contentType(string ct)
+        @safe { m_data.headers["Content-Type"] = ct; }
+
+        @property scope string contentTypeParameters() const 
+        @safe { return m_data.contentTypeParameters; }
+
+        @property scope NetworkAddress clientAddress() const 
+        @safe { return m_data.clientAddress; }
+
+        // ditto
+        @property void clientAddress(NetworkAddress naddr)
+        @safe { m_data.clientAddress = naddr; }
+
+        @property scope bool tls() const @safe { return m_data.tls; }
+
+        // ditto
+        @property void tls(bool val)
+        @safe { m_data.tls = val; }
+
+        @property scope HTTPMethod method() const @safe { return m_data.method; }
+
+        // ditto
+        @property void method(HTTPMethod m) @safe { m_data.method = m; }
+
+        @property scope HTTPServerSettings m_settings()
+        @safe { return m_data.m_settings; }
+
+        // ditto
+        @property void m_settings(HTTPServerSettings settings)
+        @safe { m_data.m_settings = settings; }
+
+		@property scope InputStream bodyReader() @safe { return m_data.bodyReader; }
+
+        // ditto
+        @property void bodyReader(InputStream inStr)
+        @safe { m_data.bodyReader = inStr; }
+
+        @property scope string password() const @safe{ return m_data.password; }
+
+        // ditto
+        @property void password(string pwd)
+        @safe{ m_data.password = pwd; }
+
+        @property scope Session session() @safe { return m_data.session; }
+
+        // ditto
+        @property void session(Session session)
+        @safe { m_data.session = session; }
+
+
+		@property scope InetPath requestPath() const @safe { return m_data.requestPath; }
+
+        // ditto
+		@property void requestPath(InetPath reqpath)
+        @safe { m_data.requestPath = reqpath; }
+
+		@property scope FilePartFormFields _files() @safe { return m_data._files; }
+
+        @property scope bool noLog() const @safe { return m_data.noLog; }
+
+        @property scope TLSCertificateInformation clientCertificate()
+        @safe {
+            return m_data.clientCertificate;
+        }
+
+        @property void clientCertificate(TLSCertificateInformation cert)
+        @safe {
+            m_data.clientCertificate = cert;
+        }
+    }
+}
+
+/**
+	Represents a HTTP response as sent from the server side.
+*/
+struct HTTPServerResponse {
+	@safe:
+
+    private HTTPServerResponseData *m_data;
+
+    this (HTTPServerResponseData *data)
+    {
+        m_data = data;
+    }
+
+	static if (!is(Stream == InterfaceProxy!Stream)) {
+		this(Stream conn, ConnectionStream raw_connection, HTTPServerSettings settings, IAllocator req_alloc)
+		@safe {
+			this(InterfaceProxy!Stream(conn), InterfaceProxy!ConnectionStream(raw_connection), settings, req_alloc);
+		}
+	}
+
+	this(InterfaceProxy!Stream conn, InterfaceProxy!ConnectionStream raw_connection, HTTPServerSettings settings, IAllocator req_alloc)
+	{
+		HTTPServerResponseData *data = new HTTPServerResponseData(conn, raw_connection, settings, req_alloc);
+		this(data);
+	}
+	
+	@property scope HTTPVersion httpVersion() { return m_data.httpVersion; }
+	@property void httpVersion(HTTPVersion h) { m_data.httpVersion = h; }
+
+	@property scope int statusCode() { return m_data.statusCode; }
+
+	@property scope string statusPhrase() { return m_data.statusPhrase; }
+
+	@property scope InetHeaderMap headers() { return m_data.headers; }
+
+	@property scope Cookie[string] cookies() { return m_data.cookies; }
+
+	@property string toString() { return m_data.toString(); }
+
+	@property scope string contentType() { return m_data.contentType(); }
+	@property void contentType(string ct) { return m_data.contentType(ct); }
+
+	@property scope SysTime timeFinalized() const { return m_data.timeFinalized; }
+
+	@property scope bool headerWritten() const { return m_data.headerWritten; }
+
+	@property scope bool isHeadResponse() const { return m_data.isHeadResponse(); }
+
+	@property scope bool tls() const { return m_data.tls(); }
+
+	@property void tls(bool v) { m_data.m_tls = v; }
+
+	@property void m_settings(HTTPServerSettings s) { m_data.m_settings = s; }
+
+	@property void m_session(Session s) { m_data.m_session = s; }
+
+	@property void m_isHeadResponse(bool b) { m_data.m_isHeadResponse = b; }
+
+	void setStatusCode(int v) { m_data.statusCode = v; }
+
+	void writeBody(in ubyte[] data, string contentType = null)
+	{
+		m_data.writeBody(data, contentType);
+	}
+	void writeBody(scope InputStream data, string content_type = null)
+	{
+		m_data.writeBody(data, content_type);
+	}
+	void writeBody(string data, string content_type = null)
+	{
+		m_data.writeBody(data, content_type);
+	}
+	void writeBody(string data, int status, string content_type = null)
+	{
+		m_data.writeBody(data, status, content_type);
+	}
+
+	void writeRawBody(RandomAccessStream)(RandomAccessStream stream) @safe
+		if (isRandomAccessStream!RandomAccessStream)
+	{
+		m_data.writeRawBody(stream);
+	}
+	/// ditto
+	void writeRawBody(InputStream)(InputStream stream, size_t num_bytes = 0) @safe
+		if (isInputStream!InputStream && !isRandomAccessStream!InputStream)
+	{
+		m_data.writeRawBody(stream, num_bytes);
+	}
+	/// ditto
+	void writeRawBody(RandomAccessStream)(RandomAccessStream stream, int status) @safe
+		if (isRandomAccessStream!RandomAccessStream)
+	{
+		m_data.writeRawBody(stream, status);
+	}
+	/// ditto
+	void writeRawBody(InputStream)(InputStream stream, int status, size_t num_bytes = 0) @safe
+		if (isInputStream!InputStream && !isRandomAccessStream!InputStream)
+	{
+		m_data.writeRawBody(stream, status, num_bytes);
+	}
+
+	/// Writes a JSON message with the specified status
+	void writeJsonBody(T)(T data, int status, bool allow_chunked = false)
+	{
+		m_data.writeJsonBody(data, status, allow_chunked);
+	}
+	/// ditto
+	void writeJsonBody(T)(T data, int status, string content_type, bool allow_chunked = false)
+	{
+		m_data.writeJsonBody(data, status, content_type, allow_chunked);
+	}
+
+	/// ditto
+	void writeJsonBody(T)(T data, string content_type, bool allow_chunked = false)
+	{
+		m_data.writeJsonBody(data, content_type, allow_chunked);
+	}
+	/// ditto
+	void writeJsonBody(T)(T data, bool allow_chunked = false)
+	{
+		m_data.writeJsonBody(data, allow_chunked);
+	}
+	/// ditto
+	void writePrettyJsonBody(T)(T data, bool allow_chunked = false)
+	{
+		m_data.writePrettyJsonBody(data, allow_chunked);
+	}
+
+	@property void writeVoidBody()
+	{
+		m_data.writeVoidBody();
+	}
+
+	@property InterfaceProxy!OutputStream bodyWriter()
+	{
+		return m_data.bodyWriter;
+	}
+
+	/** Sends a redirect request to the client.
+
+		Params:
+			url = The URL to redirect to
+			status = The HTTP redirect status (3xx) to send - by default this is $(D HTTPStatus.found)
+	*/
+	void redirect(T)(T url, int status = HTTPStatus.Found)
+	if(is(typeof(url) == string) || is(typeof(url) == URL))
+	{
+		m_data.redirect(url, status);
+	}
+
+	/** Special method sending a SWITCHING_PROTOCOLS response to the client.
+
+		Notice: For the overload that returns a `ConnectionStream`, it must be
+			ensured that the returned instance doesn't outlive the request
+			handler callback.
+
+		Params:
+			protocol = The protocol set in the "Upgrade" header of the response.
+				Use an empty string to skip setting this field.
+	*/
+	scope ConnectionStream switchProtocol(string protocol)
+	{
+		return m_data.switchProtocol(protocol);
+	}
+	/// ditto
+	void switchProtocol(string protocol, scope void delegate(scope ConnectionStream) @safe del)
+	{
+		m_data.switchProtocol(protocol, del);
+	}
+
+	/** Special method for handling CONNECT proxy tunnel
+
+		Notice: For the overload that returns a `ConnectionStream`, it must be
+			ensured that the returned instance doesn't outlive the request
+			handler callback.
+	*/
+	scope ConnectionStream connectProxy()
+	{
+		return m_data.connectProxy();
+	}
+	/// ditto
+	void connectProxy(scope void delegate(scope ConnectionStream) @safe del)
+	{
+		m_data.connectProxy(del);
+	}
+
+	/** Sets the specified cookie value.
+
+		Params:
+			name = Name of the cookie
+			value = New cookie value - pass null to clear the cookie
+			path = Path (as seen by the client) of the directory tree in which the cookie is visible
+	*/
+	scope Cookie setCookie(string name, string value, string path = "/", Cookie.Encoding encoding = Cookie.Encoding.url)
+	{
+		return m_data.setCookie(name, value, path, encoding);
+	}
+
+	/**
+		Initiates a new session.
+
+		The session is stored in the SessionStore that was specified when
+		creating the server. Depending on this, the session can be persistent
+		or temporary and specific to this server instance.
+	*/
+	scope Session startSession(string path = "/", SessionOption options = SessionOption.httpOnly)
+	{
+		return m_data.startSession(path, options);
+	}
+
+	/**
+		Terminates the current session (if any).
+	*/
+	void terminateSession()
+	{
+		m_data.terminateSession();
+	}
+
+	@property scope ulong bytesWritten() const { return m_data.bytesWritten; }
+
+	/**
+		Waits until either the connection closes, data arrives, or until the
+		given timeout is reached.
+
+		Returns:
+			$(D true) if the connection was closed and $(D false) if either the
+			timeout was reached, or if data has arrived for consumption.
+
+		See_Also: `connected`
+	*/
+	bool waitForConnectionClose(Duration timeout = Duration.max)
+	{
+		return m_data.waitForConnectionClose(timeout);
+	}
+
+	/**
+		Determines if the underlying connection is still alive.
+
+		Returns $(D true) if the remote peer is still connected and $(D false)
+		if the remote peer closed the connection.
+
+		See_Also: `waitForConnectionClose`
+	*/
+	@property bool connected() const { return m_data.connected;	}
+
+	/**
+		Finalizes the response. This is usually called automatically by the server.
+
+		This method can be called manually after writing the response to force
+		all network traffic associated with the current request to be finalized.
+		After the call returns, the `timeFinalized` property will be set.
+	*/
+	void finalize() { m_data.finalize(); }
+}
+
+
+/**
+	Represents the request listener for a specific `listenHTTP` call.
+
+	This struct can be used to stop listening for HTTP requests at runtime.
+*/
+struct HTTPListener {
+	private {
+		size_t[] m_virtualHostIDs;
+	}
+
+	private this(size_t[] ids) @safe { m_virtualHostIDs = ids; }
+
+	@property NetworkAddress[] bindAddresses()
+	{
+		NetworkAddress[] ret;
+		foreach (l; s_contexts)
+			if (l.m_virtualHosts.canFind!(v => m_virtualHostIDs.canFind(v.id))) {
+				NetworkAddress a;
+				a = resolveHost(l.bindAddress);
+				a.port = l.bindPort;
+				ret ~= a;
+			}
+		return ret;
+	}
+
+	/** Stops handling HTTP requests and closes the TCP listening port if
+		possible.
+	*/
+	void stopListening()
+	@safe {
+		import std.algorithm : countUntil;
+
+		foreach (vhid; m_virtualHostIDs) {
+			foreach (lidx, l; s_contexts) {
+				if (l.removeVirtualHost(vhid)) {
+					if (!l.hasVirtualHosts) {
+						l.stopListening();
+                        logInfo("Stopped to listen for HTTP%s requests on %s:%s", l.tlsContext ? "S": "", l.bindAddress, l.bindPort);
+						logInfo("Stopped to listen for HTTP%s requests on %s:%s", "", l.bindAddress, l.bindPort);
+						s_contexts = s_contexts[0 .. lidx] ~ s_contexts[lidx+1 .. $];
+					}
+				}
+				break;
+			}
+		}
+	}
+}
+
+/** Represents a single HTTP server port.
+
+    This class defines the incoming interface, port, and TLS configuration of
+    the public server port. The public server port may differ from the local
+    one if a reverse proxy of some kind is facing the public internet and
+    forwards to this HTTP server.
+
+    Multiple virtual hosts can be configured to be served from the same port.
+    Their TLS settings must be compatible and each virtual host must have a
+*/
+final class HTTPServerContext {
+	struct VirtualHost {
+		HTTPServerRequestDelegate requestHandler;
+		HTTPServerSettings settings;
+		HTTPLogger[] loggers;
+		size_t id;
+	}
+
+	private {
+		TCPListener m_listener;
+		VirtualHost[] m_virtualHosts;
+		string m_bindAddress;
+		ushort m_bindPort;
+        TLSContext m_tlsContext;
+		static size_t s_vhostIDCounter = 1;
+	}
+
+	@safe:
+
+	this(string bind_address, ushort bind_port)
+	{
+		m_bindAddress = bind_address;
+		m_bindPort = bind_port;
+	}
+
+	/** Returns the TLS context associated with the listener.
+
+		For non-HTTPS listeners, `null` will be returned. Otherwise, if only a
+		single virtual host has been added, the TLS context of that host's
+		settings is returned. For multiple virtual hosts, an SNI context is
+		returned, which forwards to the individual contexts based on the
+		requested host name.
+	*/
+    @property TLSContext tlsContext() { return m_tlsContext; }
+
+	/// The local network interface IP address associated with this listener
+	@property string bindAddress() const { return m_bindAddress; }
+
+	/// The local port associated with this listener
+	@property ushort bindPort() const { return m_bindPort; }
+
+	/// Determines if any virtual hosts have been addded
+	@property bool hasVirtualHosts() const { return m_virtualHosts.length > 0; }
+
+    /// Make m_virtualhosts visible
+    @property scope VirtualHost[] virtualHosts() { return m_virtualHosts; }
+
+	/** Adds a single virtual host.
+
+		Note that the port and bind address defined in `settings` must match the
+		ones for this listener. The `settings.host` field must be unique for
+		all virtual hosts.
+
+		Returns: Returns a unique ID for the new virtual host
+	*/
+	size_t addVirtualHost(HTTPServerSettings settings, HTTPServerRequestDelegate request_handler)
+	{
+		assert(settings.port == 0 || settings.port == m_bindPort, "Virtual host settings do not match bind port.");
+		assert(settings.bindAddresses.canFind(m_bindAddress), "Virtual host settings do not match bind address.");
+
+		VirtualHost vhost;
+		vhost.id = s_vhostIDCounter++;
+		vhost.settings = settings;
+		vhost.requestHandler = request_handler;
+
+		if (settings.accessLogger) vhost.loggers ~= settings.accessLogger;
+		if (settings.accessLogToConsole)
+			vhost.loggers ~= new HTTPConsoleLogger(settings, settings.accessLogFormat);
+		if (settings.accessLogFile.length)
+			vhost.loggers ~= new HTTPFileLogger(settings, settings.accessLogFormat, settings.accessLogFile);
+
+        if (!m_virtualHosts.length) m_tlsContext = settings.tlsContext;
+
+        enforce((m_tlsContext !is null) == (settings.tlsContext !is null),
+            "Cannot mix HTTP and HTTPS virtual hosts within the same listener.");
+
+        if (m_tlsContext) addSNIHost(settings);
+
+		m_virtualHosts ~= vhost;
+
+		if (settings.hostName.length) {
+            auto proto = settings.tlsContext ? "https" : "http";
+            auto port = settings.tlsContext && settings.port == 443 || !settings.tlsContext && settings.port == 80 ? "" : ":" ~ settings.port.to!string;
+			logInfo("Added virtual host %s://%s:%s/ (%s)", proto, settings.hostName, m_bindPort, m_bindAddress);
+		}
+
+		return vhost.id;
+	}
+
+	/// Removes a previously added virtual host using its ID.
+	bool removeVirtualHost(size_t id)
+	{
+		import std.algorithm.searching : countUntil;
+
+		auto idx = m_virtualHosts.countUntil!(c => c.id == id);
+		if (idx < 0) return false;
+
+		auto ctx = m_virtualHosts[idx];
+		m_virtualHosts = m_virtualHosts[0 .. idx] ~ m_virtualHosts[idx+1 .. $];
+		return true;
+	}
+
+	void stopListening()
+	{
+		m_listener.stopListening();
+	}
+
+    private void addSNIHost(HTTPServerSettings settings)
+    {
+        if (settings.tlsContext !is m_tlsContext && m_tlsContext.kind != TLSContextKind.serverSNI) {
+            logDebug("Create SNI TLS context for %s, port %s", bindAddress, bindPort);
+            m_tlsContext = createTLSContext(TLSContextKind.serverSNI);
+            m_tlsContext.sniCallback = &onSNI;
+        }
+
+    }
+
+    private TLSContext onSNI(string servername)
+    {
+        foreach (vhost; m_virtualHosts)
+            if (vhost.settings.hostName.icmp(servername) == 0) {
+                logDebug("Found context for SNI host '%s'.", servername);
+                return vhost.settings.tlsContext;
+            }
+        logDebug("No context found for SNI host '%s'.", servername);
+        return null;
+    }
+}
+
+
+/**************************************************************************************************/
+/* Private types                                                                                  */
+/**************************************************************************************************/
+
+private enum MaxHTTPHeaderLineLength = 4096;
+
+/**************************************************************************************************/
+/* Private functions                                                                              */
+/**************************************************************************************************/
+
+private {
+	import core.sync.mutex;
+
+	shared string s_distHost;
+	shared ushort s_distPort = 11000;
+
+	HTTPServerContext[] s_listeners;
 }
 
 
@@ -46,7 +1311,1222 @@ private {
 	HTTPContext[] s_contexts;
 }
 
-private HTTPContext getDefaultHTTPContext(in ref NetworkAddress addr)
+//private HTTPContext getDefaultHTTPContext(in ref NetworkAddress addr)
+
+	//assert(false, "TODO");
+//}
+
+
+/**
+  [private] Starts a HTTP server listening on the specified port.
+
+  This is the same as listenHTTP() except that it does not use a VibeDist host for
+  remote listening, even if specified on the command line.
+*/
+
+private HTTPListener listenHTTPPlain(HTTPServerSettings settings, HTTPServerRequestDelegate request_handler)
+@safe
 {
-	assert(false, "TODO");
+	import vibe.core.core : runWorkerTaskDist;
+	import std.algorithm : canFind, find;
+
+	static TCPListener doListen(HTTPServerContext listen_info, bool dist, bool reusePort)
+	@safe {
+		try {
+			TCPListenOptions options = TCPListenOptions.defaults;
+			if(reusePort) options |= TCPListenOptions.reusePort; else options &= ~TCPListenOptions.reusePort;
+			auto ret = listenTCP(listen_info.bindPort, (TCPConnection conn) nothrow @safe {
+					logInfo("ListenHTTP");
+					try { handleHTTP1Connection(conn, listen_info); 
+					} catch (Exception e) {
+						logError("HTTP connection handler has thrown: %s", e.msg);
+						debug logDebug("Full error: %s", () @trusted { return e.toString().sanitize(); } ());
+						try conn.close();
+						catch (Exception e) logError("Failed to close connection: %s", e.msg);
+					}
+				}, listen_info.bindAddress, options);
+
+			// support port 0 meaning any available port
+			if (listen_info.bindPort == 0)
+				listen_info.m_bindPort = ret.bindAddress.port;
+
+            auto proto = listen_info.tlsContext ? "https" : "http";
+			auto urladdr = listen_info.bindAddress;
+			if (urladdr.canFind(':')) urladdr = "["~urladdr~"]";
+			logInfo("Listening for requests on %s://%s:%s/", proto, urladdr, listen_info.bindPort);
+			return ret;
+		} catch( Exception e ) {
+			logWarn("Failed to listen on %s:%s", listen_info.bindAddress, listen_info.bindPort);
+			return TCPListener.init;
+		}
+	}
+
+	size_t[] vid;
+
+	// Check for every bind address/port, if a new listening socket needs to be created and
+	// check for conflicting servers
+	foreach (addr; settings.bindAddresses) {
+		HTTPServerContext linfo;
+
+		auto l = s_contexts.find!(l => l.bindAddress == addr && l.bindPort == settings.port);
+		if (!l.empty) linfo = l.front;
+		else {
+			auto li = new HTTPServerContext(addr, settings.port);
+			if (auto tcp_lst = doListen(li, (settings.options & HTTPServerOptionImpl.distribute) != 0, (settings.options & HTTPServerOption.reusePort) != 0)) // DMD BUG 2043
+			{
+				li.m_listener = tcp_lst;
+				s_contexts ~= li;
+				linfo = li;
+			}
+		}
+
+		if (linfo) vid ~= linfo.addVirtualHost(settings, request_handler);
+	}
+
+	enforce(vid.length > 0, "Failed to listen for incoming HTTP connections on any of the supplied interfaces.");
+
+	return HTTPListener(vid);
 }
+
+unittest{
+    // testing a class that implements HTTPServerRequestHandler
+
+    class MyReqHandler : HTTPServerRequestHandler
+    {
+        override void handleRequest(HTTPServerRequest req, HTTPServerResponse res)
+        @safe {
+            if (req.path == "/")
+            res.writeBody("Hello, World! Interface");
+        }
+    }
+
+	auto settings = new HTTPServerSettings();
+	settings.port = 8050;
+	settings.bindAddresses = ["localhost"];
+
+    MyReqHandler mrh = new MyReqHandler;
+
+    listenHTTP!mrh(settings);
+}
+
+unittest {
+    // testing a callable as request handler
+    void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
+    @safe {
+        if (req.path == "/")
+        res.writeBody("Hello, World! Delegate");
+    }
+
+	auto settings = new HTTPServerSettings();
+	settings.port = 8060;
+	settings.bindAddresses = ["localhost"];
+
+    listenHTTP!handleRequest(settings);
+}
+
+unittest {
+    // testing HTTPS connections
+    void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
+    @safe {
+        if (req.path == "/")
+        res.writeBody("Hello, World! Delegate");
+    }
+
+    auto settings = new HTTPServerSettings();
+    settings.port = 8070;
+    settings.bindAddresses = ["localhost"];
+    settings.tlsContext = createTLSContext(TLSContextKind.server);
+    settings.tlsContext.useCertificateChainFile("test/dummy-server-cert.pem");
+    settings.tlsContext.usePrivateKeyFile("test/dummy-server-key.pem");
+
+    listenHTTP!handleRequest(settings);
+}
+
+//// NOTE: just a possible idea for the low level api
+//struct HTTPRequestHandler {
+	//void read(alias HeaderCallback, alias BodyCallback)()
+	//{
+		//connection.readHeaders!HeaderCallback();
+		//connection.readBody!BodyCallback();
+	//}
+
+	//void write(alias HeaderCallback, alias BodyCallback)()
+	//{
+		//connection.writeHeaders!HeaderCallback();
+		//connection.writeBody!BodyCallback();
+	//}
+//}
+
+
+struct HTTPServerRequestData {
+	@disable this(this);
+
+	@safe:
+
+	private {
+		SysTime m_timeCreated;
+		HTTPServerSettings m_settings;
+		ushort m_port;
+		string m_peer;
+	}
+
+	protected {
+
+		InterfaceProxy!Stream m_conn;
+
+		/// The HTTP protocol version used for the request
+			
+		HTTPVersion httpVersion = HTTPVersion.HTTP_1_1;
+
+		/// The HTTP _method of the request
+		HTTPMethod method = HTTPMethod.GET;
+
+		/** The request URI
+
+			Note that the request URI usually does not include the global
+			'http://server' part, but only the local path and a query string.
+			A possible exception is a proxy server, which will get full URLs.
+		*/
+		string requestURI = "/";
+
+		/// Compatibility alias - scheduled for deprecation
+		alias requestURL = requestURI;
+
+		/// All request _headers
+		InetHeaderMap headers;
+
+		/// The IP address of the client
+		@property string peer()
+		@safe nothrow {
+			if (!m_peer) {
+				version (Have_vibe_core) {} else scope (failure) assert(false);
+				// store the IP address (IPv4 addresses forwarded over IPv6 are stored in IPv4 format)
+				auto peer_address_string = this.clientAddress.toString();
+				if (peer_address_string.startsWith("::ffff:") && peer_address_string[7 .. $].indexOf(':') < 0)
+					m_peer = peer_address_string[7 .. $];
+				else m_peer = peer_address_string;
+			}
+			return m_peer;
+		}
+
+		/// ditto
+		NetworkAddress clientAddress;
+
+		/// Determines if the request should be logged to the access log file.
+		bool noLog;
+
+		/// Determines if the request was issued over an TLS encrypted channel.
+		bool tls;
+
+		/* Information about the TLS certificate provided by the client.
+
+			Remarks: This field is only set if `tls` is true, and the peer
+			presented a client certificate.
+		*/
+        TLSCertificateInformation clientCertificate;
+
+		/* Deprecated: The _path part of the URL.
+
+			Note that this function contains the decoded version of the
+			requested path, which can yield incorrect results if the path
+			contains URL encoded path separators. Use `requestPath` instead to
+			get an encoding-aware representation.
+		*/
+		string path() @safe {
+			if (_path.isNull) {
+				_path = urlDecode(requestPath.toString);
+			}
+			return _path.get;
+		}
+
+		private Nullable!string _path;
+
+		//* The path part of the requested URI.
+		InetPath requestPath;
+
+		//* The user name part of the URL, if present.
+		string username;
+
+		//* The _password part of the URL, if present.
+		string password;
+
+		//* The _query string part of the URL.
+		string queryString;
+
+		/* Contains the list of _cookies that are stored on the client.
+
+			Note that the a single cookie name may occur multiple times if multiple
+			cookies have that name but different paths or domains that all match
+			the request URI. By default, the first cookie will be returned, which is
+			the or one of the cookies with the closest path match.
+		*/
+		@property ref CookieValueMap cookies() @safe {
+			if (_cookies.isNull) {
+				_cookies = CookieValueMap.init;
+				if (auto pv = "cookie" in headers)
+					parseCookies(*pv, _cookies);
+			}
+			return _cookies.get;
+		}
+		private Nullable!CookieValueMap _cookies;
+
+		/* Contains all _form fields supplied using the _query string.
+
+			The fields are stored in the same order as they are received.
+		*/
+		@property ref FormFields query() @safe {
+			if (_query.isNull) {
+				_query = FormFields.init;
+				parseURLEncodedForm(queryString, _query);
+			}
+
+			return _query.get;
+		}
+		Nullable!FormFields _query;
+
+		import vibe.utils.dictionarylist;
+		/* A map of general parameters for the request.
+
+			This map is supposed to be used by middleware functionality to store
+			information for later stages. For example vibe.http.router.URLRouter uses this map
+			to store the value of any named placeholders.
+		*/
+
+		import std.variant : Variant;
+		/* A map of context items for the request.
+
+			This is especially useful for passing application specific data down
+			the chain of processors along with the request itself.
+
+			For example, a generic route may be defined to check user login status,
+			if the user is logged in, add a reference to user specific data to the
+			context.
+
+			This is implemented with `std.variant.Variant` to allow any type of data.
+		*/
+		DictionaryList!(Variant, true, 2) context;
+
+		/* Supplies the request body as a stream.
+
+			Note that when certain server options are set (such as
+			HTTPServerOption.parseJsonBody) and a matching request was sent,
+			the returned stream will be empty. If needed, remove those
+			options and do your own processing of the body when launching
+			the server. HTTPServerOption has a list of all options that affect
+			the request body.
+		*/
+		InputStream bodyReader;
+
+		/* Contains the parsed Json for a JSON request.
+
+			A JSON request must have the Content-Type "application/json" or "application/vnd.api+json".
+		*/
+		@property ref Json json() @safe {
+			if (_json.isNull) {
+				if (icmp2(contentType, "application/json") == 0 || icmp2(contentType, "application/vnd.api+json") == 0 ) {
+					auto bodyStr = bodyReader.readAllUTF8();
+					if (!bodyStr.empty) _json = parseJson(bodyStr);
+				} else {
+					_json = Json.undefined;
+				}
+			}
+			return _json.get;
+		}
+
+		private Nullable!Json _json;
+
+		/* Contains the parsed parameters of a HTML POST _form request.
+
+			The fields are stored in the same order as they are received.
+
+			Remarks:
+				A form request must either have the Content-Type
+				"application/x-www-form-urlencoded" or "multipart/form-data".
+		*/
+		@property ref FormFields form() @safe {
+			if (_form.isNull)
+				parseFormAndFiles();
+
+			return _form.get;
+		}
+
+		private Nullable!FormFields _form;
+
+		private void parseFormAndFiles() @safe {
+			_form = FormFields.init;
+			assert(!!bodyReader);
+			parseFormData(_form, _files, headers.get("Content-Type", ""), bodyReader, MaxHTTPHeaderLineLength);
+		}
+
+		//* Contains information about any uploaded file for a HTML _form request.
+		@property ref FilePartFormFields files() @safe {
+			// _form and _files are parsed in one step
+			if (_form.isNull) {
+				parseFormAndFiles();
+				assert(!_form.isNull);
+			}
+
+			return _files;
+		}
+
+		private FilePartFormFields _files;
+
+		/* The current Session object.
+
+			This field is set if HTTPServerResponse.startSession() has been called
+			on a previous response and if the client has sent back the matching
+			cookie.
+
+			Remarks: Requires the HTTPServerOption.parseCookies option.
+		*/
+		Session session;
+
+		public string toString()
+		{
+			return httpMethodString(method) ~ " " ~ requestURL ~ " " ~ getHTTPVersionString(httpVersion);
+		}
+
+		/** Shortcut to the 'Host' header (always present for HTTP 1.1)
+		 */
+		@property string host() const { auto ph = "Host" in headers; return ph ? *ph : null; }
+		/// ditto
+		@property void host(string v) { headers["Host"] = v; }
+
+		/** Returns the mime type part of the 'Content-Type' header.
+
+		  This function gets the pure mime type (e.g. "text/plain")
+		  without any supplimentary parameters such as "charset=...".
+		  Use contentTypeParameters to get any parameter string or
+		  headers["Content-Type"] to get the raw value.
+		 */
+		@property string contentType()
+			const {
+				auto pv = "Content-Type" in headers;
+				if( !pv ) return null;
+				auto idx = std.string.indexOf(*pv, ';');
+				return idx >= 0 ? (*pv)[0 .. idx] : *pv;
+			}
+		/// ditto
+		@property void contentType(string ct) { headers["Content-Type"] = ct; }
+
+		/** Returns any supplementary parameters of the 'Content-Type' header.
+
+		  This is a semicolon separated ist of key/value pairs. Usually, if set,
+		  this contains the character set used for text based content types.
+		 */
+		@property string contentTypeParameters()
+		const {
+			auto pv = "Content-Type" in headers;
+			if( !pv ) return null;
+			auto idx = std.string.indexOf(*pv, ';');
+			return idx >= 0 ? (*pv)[idx+1 .. $] : null;
+		}
+
+		/** Determines if the connection persists across requests.
+		*/
+		@property bool persistent() const
+		{
+			auto ph = "connection" in headers;
+			switch(httpVersion) {
+				case HTTPVersion.HTTP_1_0:
+					if (ph && toLower(*ph) == "keep-alive") return true;
+					return false;
+				case HTTPVersion.HTTP_1_1:
+					if (ph && toLower(*ph) != "keep-alive") return false;
+					return true;
+				default:
+					return false;
+			}
+		}
+	}
+
+	package {
+		//* The settings of the server serving this request.
+		@property const(HTTPServerSettings) serverSettings() const @safe
+		{
+			return m_settings;
+		}
+	}
+
+	this(SysTime time, ushort port)
+	@safe {
+		m_timeCreated = time.toUTC();
+		m_port = port;
+	}
+
+	//* Time when this request started processing.
+	@property SysTime timeCreated() const @safe { return m_timeCreated; }
+
+
+	/* The full URL that corresponds to this request.
+
+		The host URL includes the protocol, host and optionally the user
+		and password that was used for this request. This field is useful to
+		construct self referencing URLs.
+
+		Note that the port is currently not set, so that this only works if
+		the standard port is used.
+	*/
+	@property URL fullURL()
+	const @safe {
+		URL url;
+
+		auto xfh = this.headers.get("X-Forwarded-Host");
+		auto xfp = this.headers.get("X-Forwarded-Port");
+		auto xfpr = this.headers.get("X-Forwarded-Proto");
+
+		// Set URL host segment.
+		if (xfh.length) {
+			url.host = xfh;
+		} else if (!this.host.empty) {
+			url.host = this.host;
+		} else if (!m_settings.hostName.empty) {
+			url.host = m_settings.hostName;
+		} else {
+			url.host = m_settings.bindAddresses[0];
+		}
+
+		// Set URL schema segment.
+		if (xfpr.length) {
+			url.schema = xfpr;
+		} else if (this.tls) {
+			url.schema = "https";
+		} else {
+			url.schema = "http";
+		}
+
+		// Set URL port segment.
+		if (xfp.length) {
+			try {
+				url.port = xfp.to!ushort;
+			} catch (ConvException) {
+				// TODO : Consider responding with a 400/etc. error from here.
+				logWarn("X-Forwarded-Port header was not valid port (%s)", xfp);
+			}
+		} else if (!xfh) {
+			if (url.schema == "https") {
+				if (m_port != 443U) url.port = m_port;
+			} else {
+				if (m_port != 80U)  url.port = m_port;
+			}
+		}
+
+		if (url.host.startsWith('[')) { // handle IPv6 address
+			auto idx = url.host.indexOf(']');
+			if (idx >= 0 && idx+1 < url.host.length && url.host[idx+1] == ':')
+				url.host = url.host[1 .. idx];
+		} else { // handle normal host names or IPv4 address
+			auto idx = url.host.indexOf(':');
+			if (idx >= 0) url.host = url.host[0 .. idx];
+		}
+
+		url.username = this.username;
+		url.password = this.password;
+		url.localURI = this.requestURI;
+
+		return url;
+	}
+
+	/* The relative path to the root folder.
+
+		Using this function instead of absolute URLs for embedded links can be
+		useful to avoid dead link when the site is piped through a
+		reverse-proxy.
+
+		The returned string always ends with a slash.
+	*/
+	@property string rootDir()
+	const @safe {
+		import std.range.primitives : walkLength;
+		auto depth = requestPath.bySegment.walkLength;
+		return depth == 0 ? "./" : replicate("../", depth);
+	}
+}
+
+
+struct HTTPServerResponseData {
+	@disable this(this);
+	@safe:
+
+	private {
+		InterfaceProxy!Stream m_conn;
+		InterfaceProxy!ConnectionStream m_rawConnection;
+		InterfaceProxy!OutputStream m_bodyWriter;
+		IAllocator m_requestAlloc;
+		FreeListRef!ChunkedOutputStream m_chunkedBodyWriter;
+		FreeListRef!CountingOutputStream m_countingWriter;
+		FreeListRef!ZlibOutputStream m_zlibOutputStream;
+		HTTPServerSettings m_settings;
+		Session m_session;
+		bool m_headerWritten = false;
+		bool m_isHeadResponse = false;
+		bool m_tls;
+		SysTime m_timeFinalized;
+	}
+
+	protected {
+		/// The protocol version of the response - should not be changed
+		HTTPVersion httpVersion = HTTPVersion.HTTP_1_1;
+
+		/// The status code of the response, 200 by default
+		int statusCode = HTTPStatus.OK;
+
+		/** The status phrase of the response
+
+			If no phrase is set, a default one corresponding to the status code will be used.
+		*/
+		string statusPhrase;
+
+		/// The response header fields
+		InetHeaderMap headers;
+
+		/// All cookies that shall be set on the client for this request
+		Cookie[string] cookies;
+		/** Shortcut to the "Content-Type" header
+		 */
+		@property string contentType() const { auto pct = "Content-Type" in headers; return pct ? *pct : "application/octet-stream"; }
+		/// ditto
+		@property void contentType(string ct) { headers["Content-Type"] = ct; }
+
+		static if (!is(Stream == InterfaceProxy!Stream)) {
+			this(Stream conn, ConnectionStream raw_connection, HTTPServerSettings settings, IAllocator req_alloc)
+				@safe {
+					this(InterfaceProxy!Stream(conn), InterfaceProxy!ConnectionStream(raw_connection), settings, req_alloc);
+				}
+		}
+
+		this(InterfaceProxy!Stream conn, InterfaceProxy!ConnectionStream raw_connection, HTTPServerSettings settings, IAllocator req_alloc)
+			@safe {
+				m_conn = conn;
+				m_rawConnection = raw_connection;
+				m_countingWriter = createCountingOutputStreamFL(conn);
+				m_settings = settings;
+				m_requestAlloc = req_alloc;
+			}
+
+		/** Returns the time at which the request was finalized.
+
+		  Note that this field will only be set after `finalize` has been called.
+		 */
+		@property SysTime timeFinalized() const @safe { return m_timeFinalized; }
+
+		/** Determines if the HTTP header has already been written.
+		 */
+		@property bool headerWritten() const @safe { return m_headerWritten; }
+
+		/** Determines if the response does not need a body.
+		 */
+		bool isHeadResponse() const @safe { return m_isHeadResponse; }
+
+		/** Determines if the response is sent over an encrypted connection.
+		 */
+		bool tls() const @safe { return m_tls; }
+
+		/** Writes the entire response body at once.
+
+			Params:
+				data = The data to write as the body contents
+				status = Optional response status code to set
+				content_tyoe = Optional content type to apply to the response.
+					If no content type is given and no "Content-Type" header is
+					set in the response, this will default to
+					`"application/octet-stream"`.
+
+			See_Also: `HTTPStatusCode`
+		 */
+		void writeBody(in ubyte[] data, string content_type = null)
+			@safe {
+				if (content_type.length) headers["Content-Type"] = content_type;
+				else if ("Content-Type" !in headers) headers["Content-Type"] = "application/octet-stream";
+				ulong length = data.length;
+				headers["Content-Length"] = formatAlloc(m_requestAlloc, "%d", length);
+				headers["Content-Length"] = format("%d", length);
+				bodyWriter.write(data);
+			}
+		/// ditto
+		void writeBody(in ubyte[] data, int status, string content_type = null)
+			@safe {
+				statusCode = status;
+				writeBody(data, content_type);
+			}
+		/// ditto
+		void writeBody(scope InputStream data, string content_type = null)
+			@safe {
+				if (content_type.length) headers["Content-Type"] = content_type;
+				else if ("Content-Type" !in headers) headers["Content-Type"] = "application/octet-stream";
+				data.pipe(bodyWriter);
+			}
+
+		/** Writes the entire response body as a single string.
+
+				Params:
+					data = The string to write as the body contents
+					status = Optional response status code to set
+					content_type = Optional content type to apply to the response.
+						If no content type is given and no "Content-Type" header is
+						set in the response, this will default to
+						`"text/plain; charset=UTF-8"`.
+
+				See_Also: `HTTPStatusCode`
+		 */
+		/// ditto
+		void writeBody(string data, string content_type = null)
+			@safe {
+				if (!content_type.length && "Content-Type" !in headers)
+					content_type = "text/plain; charset=UTF-8";
+				writeBody(cast(const(ubyte)[])data, content_type);
+			}
+		/// ditto
+		void writeBody(string data, int status, string content_type = null)
+			@safe {
+				statusCode = status;
+				writeBody(data, content_type);
+			}
+
+		/** Writes the whole response body at once, without doing any further encoding.
+
+		  	  The caller has to make sure that the appropriate headers are set correctly
+		  	  (i.e. Content-Type and Content-Encoding).
+
+		  	  Note that the version taking a RandomAccessStream may perform additional
+		  	  optimizations such as sending a file directly from the disk to the
+		  	  network card using a DMA transfer.
+
+		 */
+		void writeRawBody(RandomAccessStream)(RandomAccessStream stream) @safe
+			if (isRandomAccessStream!RandomAccessStream)
+			{
+				assert(!m_headerWritten, "A body was already written!");
+				writeHeader();
+				if (m_isHeadResponse) return;
+
+				auto bytes = stream.size - stream.tell();
+				stream.pipe(m_conn);
+				m_countingWriter.increment(bytes);
+			}
+		/// ditto
+		void writeRawBody(InputStream)(InputStream stream, size_t num_bytes = 0) @safe
+			if (isInputStream!InputStream && !isRandomAccessStream!InputStream)
+			{
+				assert(!m_headerWritten, "A body was already written!");
+				writeHeader();
+				if (m_isHeadResponse) return;
+
+				if (num_bytes > 0) {
+					stream.pipe(m_conn, num_bytes);
+					m_countingWriter.increment(num_bytes);
+				} else stream.pipe(m_countingWriter, num_bytes);
+			}
+		/// ditto
+		void writeRawBody(RandomAccessStream)(RandomAccessStream stream, int status) @safe
+			if (isRandomAccessStream!RandomAccessStream)
+			{
+				statusCode = status;
+				writeRawBody(stream);
+			}
+		/// ditto
+		void writeRawBody(InputStream)(InputStream stream, int status, size_t num_bytes = 0) @safe
+			if (isInputStream!InputStream && !isRandomAccessStream!InputStream)
+			{
+				statusCode = status;
+				writeRawBody(stream, num_bytes);
+			}
+
+
+		/// Writes a JSON message with the specified status
+		void writeJsonBody(T)(T data, int status, bool allow_chunked = false)
+		{
+			statusCode = status;
+			writeJsonBody(data, allow_chunked);
+		}
+		/// ditto
+		void writeJsonBody(T)(T data, int status, string content_type, bool allow_chunked = false)
+		{
+			statusCode = status;
+			writeJsonBody(data, content_type, allow_chunked);
+		}
+
+		/// ditto
+		void writeJsonBody(T)(T data, string content_type, bool allow_chunked = false)
+		{
+			headers["Content-Type"] = content_type;
+			writeJsonBody(data, allow_chunked);
+		}
+		/// ditto
+		void writeJsonBody(T)(T data, bool allow_chunked = false)
+		{
+			doWriteJsonBody!(T, false)(data, allow_chunked);
+		}
+		/// ditto
+		void writePrettyJsonBody(T)(T data, bool allow_chunked = false)
+		{
+			doWriteJsonBody!(T, true)(data, allow_chunked);
+		}
+
+		private void doWriteJsonBody(T, bool PRETTY)(T data, bool allow_chunked = false)
+		{
+			import std.traits;
+			import vibe.stream.wrapper;
+
+			static if (!is(T == Json) && is(typeof(data.data())) && isArray!(typeof(data.data()))) {
+				static assert(!is(T == Appender!(typeof(data.data()))), "Passed an Appender!T to writeJsonBody - this is most probably not doing what's indended.");
+			}
+
+			if ("Content-Type" !in headers)
+				headers["Content-Type"] = "application/json; charset=UTF-8";
+
+
+			// set an explicit content-length field if chunked encoding is not allowed
+			if (!allow_chunked) {
+				import vibe.internal.rangeutil;
+				long length = 0;
+				auto counter = RangeCounter(() @trusted { return &length; } ());
+				static if (PRETTY) serializeToPrettyJson(counter, data);
+				else serializeToJson(counter, data);
+				headers["Content-Length"] = formatAlloc(m_requestAlloc, "%d", length);
+			}
+
+			auto rng = streamOutputRange!1024(bodyWriter);
+			static if (PRETTY) serializeToPrettyJson(() @trusted { return &rng; } (), data);
+			else serializeToJson(() @trusted { return &rng; } (), data);
+		}
+
+		/**
+	 	 * Writes the response with no body.
+	 	 *
+	 	 * This method should be used in situations where no body is
+	 	 * requested, such as a HEAD request. For an empty body, just use writeBody,
+	 	 * as this method causes problems with some keep-alive connections.
+	 	 */
+		void writeVoidBody()
+			@safe {
+				if (!m_isHeadResponse) {
+					assert("Content-Length" !in headers);
+					assert("Transfer-Encoding" !in headers);
+				}
+				assert(!headerWritten);
+				writeHeader();
+				m_conn.flush();
+			}
+
+		/** A stream for writing the body of the HTTP response.
+
+		  	  Note that after 'bodyWriter' has been accessed for the first time, it
+		  	  is not allowed to change any header or the status code of the response.
+		 */
+		@property InterfaceProxy!OutputStream bodyWriter()
+			@safe {
+				assert(!!m_conn);
+				if (m_bodyWriter) return m_bodyWriter;
+
+				assert(!m_headerWritten, "A void body was already written!");
+
+				if (m_isHeadResponse) {
+					// for HEAD requests, we define a NullOutputWriter for convenience
+					// - no body will be written. However, the request handler should call writeVoidBody()
+					// and skip writing of the body in this case.
+					if ("Content-Length" !in headers)
+						headers["Transfer-Encoding"] = "chunked";
+					writeHeader();
+					m_bodyWriter = nullSink;
+					return m_bodyWriter;
+				}
+
+				if ("Content-Encoding" in headers && "Content-Length" in headers) {
+					// we do not known how large the compressed body will be in advance
+					// so remove the content-length and use chunked transfer
+					headers.remove("Content-Length");
+				}
+
+				if (auto pcl = "Content-Length" in headers) {
+					writeHeader();
+					m_countingWriter.writeLimit = (*pcl).to!ulong;
+					m_bodyWriter = m_countingWriter;
+				} else if (httpVersion <= HTTPVersion.HTTP_1_0) {
+					if ("Connection" in headers)
+						headers.remove("Connection"); // default to "close"
+					writeHeader();
+					m_bodyWriter = m_conn;
+				} else {
+					headers["Transfer-Encoding"] = "chunked";
+					writeHeader();
+					m_chunkedBodyWriter = createChunkedOutputStreamFL(m_countingWriter);
+					m_bodyWriter = m_chunkedBodyWriter;
+				}
+
+				if (auto pce = "Content-Encoding" in headers) {
+					if (icmp2(*pce, "gzip") == 0) {
+						m_zlibOutputStream = createGzipOutputStreamFL(m_bodyWriter);
+						m_bodyWriter = m_zlibOutputStream;
+					} else if (icmp2(*pce, "deflate") == 0) {
+						m_zlibOutputStream = createDeflateOutputStreamFL(m_bodyWriter);
+						m_bodyWriter = m_zlibOutputStream;
+					} else {
+						logWarn("Unsupported Content-Encoding set in response: '"~*pce~"'");
+					}
+				}
+
+				return m_bodyWriter;
+			}
+
+		/** Sends a redirect request to the client.
+
+				Params:
+					url = The URL to redirect to
+					status = The HTTP redirect status (3xx) to send - by default this is $(D HTTPStatus.found)
+		 */
+		void redirect(string url, int status = HTTPStatus.Found)
+			@safe {
+				// Disallow any characters that may influence the header parsing
+				enforce(!url.representation.canFind!(ch => ch < 0x20),
+						"Control character in redirection URL.");
+
+				statusCode = status;
+				headers["Location"] = url;
+				writeBody("redirecting...");
+			}
+		/// ditto
+		void redirect(URL url, int status = HTTPStatus.Found)
+			@safe {
+				redirect(url.toString(), status);
+			}
+
+		///
+		@safe unittest {
+			import vibe.http.router;
+
+			void request_handler(HTTPServerRequest req, HTTPServerResponse res)
+			{
+				res.redirect("http://example.org/some_other_url");
+			}
+
+			void test()
+			{
+				auto router = new URLRouter;
+				router.get("/old_url", &request_handler);
+				listenHTTP!router(new HTTPServerSettings);
+			}
+		}
+
+
+		/** Special method sending a SWITCHING_PROTOCOLS response to the client.
+
+				Notice: For the overload that returns a `ConnectionStream`, it must be
+					ensured that the returned instance doesn't outlive the request
+					handler callback.
+
+				Params:
+					protocol = The protocol set in the "Upgrade" header of the response.
+					Use an empty string to skip setting this field.
+		 */
+		ConnectionStream switchProtocol(string protocol)
+			@safe {
+				statusCode = HTTPStatus.SwitchingProtocols;
+				if (protocol.length) headers["Upgrade"] = protocol;
+				writeVoidBody();
+				return createConnectionProxyStream(m_conn, m_rawConnection);
+			}
+		/// ditto
+		void switchProtocol(string protocol, scope void delegate(scope ConnectionStream) @safe del)
+			@safe {
+				statusCode = HTTPStatus.SwitchingProtocols;
+				if (protocol.length) headers["Upgrade"] = protocol;
+				writeVoidBody();
+				() @trusted {
+					auto conn = createConnectionProxyStreamFL(m_conn, m_rawConnection);
+					del(conn);
+				} ();
+				finalize();
+				if (m_rawConnection && m_rawConnection.connected)
+					m_rawConnection.close(); // connection not reusable after a protocol upgrade
+			}
+
+		/** Special method for handling CONNECT proxy tunnel
+
+				Notice: For the overload that returns a `ConnectionStream`, it must be
+					ensured that the returned instance doesn't outlive the request
+					handler callback.
+		 */
+		ConnectionStream connectProxy()
+			@safe {
+				return createConnectionProxyStream(m_conn, m_rawConnection);
+			}
+		/// ditto
+		void connectProxy(scope void delegate(scope ConnectionStream) @safe del)
+			@safe {
+				() @trusted {
+					auto conn = createConnectionProxyStreamFL(m_conn, m_rawConnection);
+					del(conn);
+				} ();
+				finalize();
+				m_rawConnection.close(); // connection not reusable after a protocol upgrade
+			}
+
+		/** Sets the specified cookie value.
+
+				Params:
+					name = Name of the cookie
+					value = New cookie value - pass null to clear the cookie
+					path = Path (as seen by the client) of the directory tree in which the cookie is visible
+		 */
+		Cookie setCookie(string name, string value, string path = "/", Cookie.Encoding encoding = Cookie.Encoding.url)
+			@safe {
+				auto cookie = new Cookie();
+				cookie.path = path;
+				cookie.setValue(value, encoding);
+				if (value is null) {
+					cookie.maxAge = 0;
+					cookie.expires = "Thu, 01 Jan 1970 00:00:00 GMT";
+				}
+				cookies[name] = cookie;
+				return cookie;
+			}
+
+		/**
+		  Initiates a new session.
+
+		  The session is stored in the SessionStore that was specified when
+		  creating the server. Depending on this, the session can be persistent
+		  or temporary and specific to this server instance.
+		 */
+		Session startSession(string path = "/", SessionOption options = SessionOption.httpOnly)
+			@safe {
+				assert(m_settings.sessionStore, "no session store set");
+				assert(!m_session, "Try to start a session, but already started one.");
+
+				bool secure;
+				if (options & SessionOption.secure) secure = true;
+				else if (options & SessionOption.noSecure) secure = false;
+				else secure = this.tls;
+
+				m_session = m_settings.sessionStore.create();
+				m_session.set("$sessionCookiePath", path);
+				m_session.set("$sessionCookieSecure", secure);
+				auto cookie = setCookie(m_settings.sessionIdCookie, m_session.id, path);
+				cookie.secure = secure;
+				cookie.httpOnly = (options & SessionOption.httpOnly) != 0;
+				return m_session;
+			}
+
+		/**
+		  Terminates the current session (if any).
+		 */
+		void terminateSession()
+			@safe {
+				if (!m_session) return;
+				auto cookie = setCookie(m_settings.sessionIdCookie, null, m_session.get!string("$sessionCookiePath"));
+				cookie.secure = m_session.get!bool("$sessionCookieSecure");
+				m_session.destroy();
+				m_session = Session.init;
+			}
+
+		@property ulong bytesWritten() @safe const { return m_countingWriter.bytesWritten; }
+
+		/**
+		  Waits until either the connection closes, data arrives, or until the
+		  given timeout is reached.
+
+				Returns:
+					$(D true) if the connection was closed and $(D false) if either the
+					timeout was reached, or if data has arrived for consumption.
+
+					See_Also: `connected`
+		 */
+		bool waitForConnectionClose(Duration timeout = Duration.max)
+			@safe {
+				if (!m_rawConnection || !m_rawConnection.connected) return true;
+				m_rawConnection.waitForData(timeout);
+				return !m_rawConnection.connected;
+			}
+
+		/**
+		  Determines if the underlying connection is still alive.
+
+		  Returns $(D true) if the remote peer is still connected and $(D false)
+		  if the remote peer closed the connection.
+
+			See_Also: `waitForConnectionClose`
+		 */
+		@property bool connected()
+			@safe const {
+				if (!m_rawConnection) return false;
+				return m_rawConnection.connected;
+			}
+
+		/**
+		  Finalizes the response. This is usually called automatically by the server.
+
+		  This method can be called manually after writing the response to force
+		  all network traffic associated with the current request to be finalized.
+		  After the call returns, the `timeFinalized` property will be set.
+		 */
+		void finalize()
+			@safe {
+				if (m_zlibOutputStream) {
+					m_zlibOutputStream.finalize();
+					m_zlibOutputStream.destroy();
+				}
+				if (m_chunkedBodyWriter) {
+					m_chunkedBodyWriter.finalize();
+					m_chunkedBodyWriter.destroy();
+				}
+
+				// ignore exceptions caused by an already closed connection - the client
+				// may have closed the connection already and this doesn't usually indicate
+				// a problem.
+				if (m_rawConnection && m_rawConnection.connected) {
+					try if (m_conn) m_conn.flush();
+					catch (Exception e) logDebug("Failed to flush connection after finishing HTTP response: %s", e.msg);
+					if (!isHeadResponse && bytesWritten < headers.get("Content-Length", "0").to!long) {
+						logDebug("HTTP response only written partially before finalization. Terminating connection.");
+						m_rawConnection.close();
+					}
+					m_rawConnection = InterfaceProxy!ConnectionStream.init;
+				}
+
+				if (m_conn) {
+					m_conn = InterfaceProxy!Stream.init;
+					m_timeFinalized = Clock.currTime(UTC());
+				}
+			}
+
+	}
+
+	private void writeHeader()
+		@safe {
+			import vibe.stream.wrapper;
+
+			assert(!m_bodyWriter && !m_headerWritten, "Try to write header after body has already begun.");
+			m_headerWritten = true;
+			auto dst = streamOutputRange!1024(m_conn);
+
+			void writeLine(T...)(string fmt, T args)
+				@safe {
+					formattedWrite(() @trusted { return &dst; } (), fmt, args);
+					dst.put("\r\n");
+					logTrace(fmt, args);
+				}
+
+			logTrace("---------------------");
+			logTrace("HTTP server response:");
+			logTrace("---------------------");
+
+			// write the status line
+			writeLine("%s %d %s",
+					getHTTPVersionString(this.httpVersion),
+					this.statusCode,
+					this.statusPhrase.length ? this.statusPhrase : httpStatusText(this.statusCode));
+
+			// write all normal headers
+			foreach (k, v; this.headers) {
+				dst.put(k);
+				dst.put(": ");
+				dst.put(v);
+				dst.put("\r\n");
+				logTrace("%s: %s", k, v);
+			}
+
+			logTrace("---------------------");
+
+			// write cookies
+			foreach (n, cookie; this.cookies) {
+				dst.put("Set-Cookie: ");
+				cookie.writeString(() @trusted { return &dst; } (), n);
+				dst.put("\r\n");
+			}
+
+			// finalize response header
+			dst.put("\r\n");
+		}
+
+	public string toString()
+	{
+		auto app = appender!string();
+		formattedWrite(app, "%s %d %s", getHTTPVersionString(this.httpVersion), this.statusCode, this.statusPhrase);
+		return app.data;
+	}
+}
+
+
+private void parseCookies(string str, ref CookieValueMap cookies)
+@safe {
+	import std.encoding : sanitize;
+	import std.array : split;
+	import std.string : strip;
+	import std.algorithm.iteration : map, filter, each;
+	import vibe.http.common : Cookie;
+	() @trusted { return str.sanitize; } ()
+		.split(";")
+		.map!(kv => kv.strip.split("="))
+		.filter!(kv => kv.length == 2) //ignore illegal cookies
+		.each!(kv => cookies.add(kv[0], kv[1], Cookie.Encoding.raw) );
+}
+
+unittest
+{
+	  auto cvm = CookieValueMap();
+	  parseCookies("foo=bar;; baz=zinga; öö=üü   ;   møøse=was=sacked;    onlyval1; =onlyval2; onlykey=", cvm);
+	  assert(cvm["foo"] == "bar");
+	  assert(cvm["baz"] == "zinga");
+	  assert(cvm["öö"] == "üü");
+	  assert( "møøse" ! in cvm); //illegal cookie gets ignored
+	  assert( "onlyval1" ! in cvm); //illegal cookie gets ignored
+	  assert(cvm["onlykey"] == "");
+	  assert(cvm[""] == "onlyval2");
+	  assert(cvm.length() == 5);
+	  cvm = CookieValueMap();
+	  parseCookies("", cvm);
+	  assert(cvm.length() == 0);
+	  cvm = CookieValueMap();
+	  parseCookies(";;=", cvm);
+	  assert(cvm.length() == 1);
+	  assert(cvm[""] == "");
+}
+
+
+void parseRequestHeader(InputStream)(HTTPServerRequest reqStruct, InputStream http_stream, IAllocator alloc, ulong max_header_size)
+	if (isInputStream!InputStream)
+{
+	auto stream = FreeListRef!LimitedHTTPInputStream(http_stream, max_header_size);
+    auto req = reqStruct.m_data;
+
+	logTrace("HTTP server reading status line");
+	auto reqln = () @trusted { return cast(string)stream.readLine(MaxHTTPHeaderLineLength, "\r\n", alloc); }();
+
+	logTrace("--------------------");
+	logTrace("HTTP server request:");
+	logTrace("--------------------");
+	logTrace("%s", reqln);
+
+	//Method
+	auto pos = reqln.indexOf(' ');
+	enforceBadRequest(pos >= 0, "invalid request method");
+
+	req.method = httpMethodFromString(reqln[0 .. pos]);
+	reqln = reqln[pos+1 .. $];
+	//Path
+	pos = reqln.indexOf(' ');
+	enforceBadRequest(pos >= 0, "invalid request path");
+
+	req.requestURI = reqln[0 .. pos];
+	reqln = reqln[pos+1 .. $];
+
+	req.httpVersion = parseHTTPVersion(reqln);
+
+	//headers
+	parseRFC5322Header(stream, req.headers, MaxHTTPHeaderLineLength, alloc, false);
+
+	foreach (k, v; req.headers)
+		logTrace("%s: %s", k, v);
+	logTrace("--------------------");
+}
+
+string formatRFC822DateAlloc(IAllocator alloc, SysTime time)
+@safe {
+    auto app = AllocAppender!string(alloc);
+    writeRFC822DateTimeString(app, time);
+    return () @trusted { return app.data; } ();
+}
+
+version (VibeDebugCatchAll) alias UncaughtException = Throwable;
+else alias UncaughtException = Exception;

--- a/source/vibe/http/session.d
+++ b/source/vibe/http/session.d
@@ -1,0 +1,294 @@
+/**
+	Cookie based session support.
+
+	Copyright: © 2012-2013 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Jan Krüger, Sönke Ludwig, Ilya Shipunov
+*/
+module vibe.http.session;
+
+import vibe.core.log;
+import vibe.crypto.cryptorand;
+
+import std.array;
+import std.base64;
+import std.traits : hasAliasing;
+import std.variant;
+
+//random number generator
+//TODO: Use Whirlpool or SHA-512 here
+private SHA1HashMixerRNG g_rng;
+
+//The "URL and Filename safe" Base64 without padding
+alias Base64URLNoPadding = Base64Impl!('-', '_', Base64.NoPadding);
+
+
+/**
+	Represents a single HTTP session.
+
+	Indexing the session object with string keys allows to store arbitrary key/value pairs.
+*/
+struct Session {
+	private {
+		SessionStore m_store;
+		string m_id;
+		SessionStorageType m_storageType;
+	}
+
+	// created by the SessionStore using SessionStore.createSessionInstance
+	private this(SessionStore store, string id = null)
+	@safe {
+		assert(id.length > 0);
+		m_store = store;
+		m_id = id;
+		m_storageType = store.storageType;
+	}
+
+	/** Checks if the session is active.
+
+		This operator enables a $(D Session) value to be used in conditionals
+		to check if they are actially valid/active.
+	*/
+	bool opCast() const @safe { return m_store !is null; }
+
+	///
+	unittest {
+		//import vibe.http.server;
+		// workaround for cyclic module ctor compiler error
+		class HTTPServerRequest { Session session; string[string] form; }
+		class HTTPServerResponse { Session startSession() { assert(false); } }
+
+		void login(scope HTTPServerRequest req, scope HTTPServerResponse res)
+		{
+			// TODO: validate username+password
+
+			// ensure that there is an active session
+			if (!req.session) req.session = res.startSession();
+
+			// update session variables
+			req.session.set("loginUser", req.form["user"]);
+		}
+	}
+
+	/// Returns the unique session id of this session.
+	@property string id() const @safe { return m_id; }
+
+	/// Queries the session for the existence of a particular key.
+	bool isKeySet(string key) @safe { return m_store.isKeySet(m_id, key); }
+
+	/** Gets a typed field from the session.
+	*/
+	const(T) get(T)(string key, lazy T def_value = T.init)
+	@trusted { // Variant, deserializeJson/deserializeBson
+		static assert(!hasAliasing!T, "Type "~T.stringof~" contains references, which is not supported for session storage.");
+		auto val = m_store.get(m_id, key, serialize(def_value));
+		return deserialize!T(val);
+	}
+
+	/** Sets a typed field to the session.
+	*/
+	void set(T)(string key, T value)
+	{
+		static assert(!hasAliasing!T, "Type "~T.stringof~" contains references, which is not supported for session storage.");
+		m_store.set(m_id, key, serialize(value));
+	}
+
+	// Removes a field from a session
+	void remove(string key) @safe { m_store.remove(m_id, key); }
+
+	/**
+		Enables foreach-iteration over all keys of the session.
+	*/
+	int opApply(scope int delegate(string key) @safe del)
+	@safe {
+		return m_store.iterateSession(m_id, del);
+	}
+	///
+	unittest {
+		//import vibe.http.server;
+		// workaround for cyclic module ctor compiler error
+		class HTTPServerRequest { Session session; }
+		class HTTPServerResponse { import vibe.core.stream; OutputStream bodyWriter() @safe { assert(false); } string contentType; }
+
+		// sends all session entries to the requesting browser
+		// assumes that all entries are strings
+		void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
+		{
+			res.contentType = "text/plain";
+			req.session.opApply((key) @safe {
+				res.bodyWriter.write(key ~ ": " ~ req.session.get!string(key) ~ "\n");
+				return 0;
+			});
+		}
+	}
+
+	package void destroy() @safe { m_store.destroy(m_id); }
+
+	private Variant serialize(T)(T val)
+	{
+		import vibe.data.json;
+		import vibe.data.bson;
+
+		final switch (m_storageType) with (SessionStorageType) {
+			case native: return () @trusted { return Variant(val); } ();
+			case json: return () @trusted { return Variant(serializeToJson(val)); } ();
+			case bson: return () @trusted { return Variant(serializeToBson(val)); } ();
+		}
+	}
+
+	private T deserialize(T)(ref Variant val)
+	{
+		import vibe.data.json;
+		import vibe.data.bson;
+
+		final switch (m_storageType) with (SessionStorageType) {
+			case native: return () @trusted { return val.get!T; } ();
+			case json: return () @trusted { return deserializeJson!T(val.get!Json); } ();
+			case bson: return () @trusted { return deserializeBson!T(val.get!Bson); } ();
+		}
+	}
+}
+
+
+/**
+	Interface for a basic session store.
+
+	A sesseion store is responsible for storing the id and the associated key/value pairs of a
+	session.
+*/
+interface SessionStore {
+@safe:
+
+	/// Returns the internal type used for storing session keys.
+	@property SessionStorageType storageType() const;
+
+	/// Creates a new session.
+	Session create();
+
+	/// Opens an existing session.
+	Session open(string id);
+
+	/// Sets a name/value pair for a given session.
+	void set(string id, string name, Variant value);
+
+	/// Returns the value for a given session key.
+	Variant get(string id, string name, lazy Variant defaultVal);
+
+	/// Determines if a certain session key is set.
+	bool isKeySet(string id, string key);
+
+	/// Removes a key from a session
+	void remove(string id, string key);
+
+	/// Terminates the given session.
+	void destroy(string id);
+
+	/// Iterates all keys stored in the given session.
+	int iterateSession(string id, scope int delegate(string key) @safe del);
+
+	/// Creates a new Session object which sources its contents from this store.
+	protected final Session createSessionInstance(string id = null)
+	{
+		if (!id.length) {
+			ubyte[64] rand;
+			if (!g_rng) g_rng = new SHA1HashMixerRNG();
+			g_rng.read(rand);
+			id = () @trusted { return cast(immutable)Base64URLNoPadding.encode(rand); } ();
+		}
+		return Session(this, id);
+	}
+}
+
+enum SessionStorageType {
+	native,
+	json,
+	bson
+}
+
+
+/**
+	Session store for storing a session in local memory.
+
+	If the server is running as a single instance (no thread or process clustering), this kind of
+	session store provies the fastest and simplest way to store sessions. In any other case,
+	a persistent session store based on a database is necessary.
+*/
+final class MemorySessionStore : SessionStore {
+@safe:
+
+	private {
+		Variant[string][string] m_sessions;
+	}
+
+	@property SessionStorageType storageType()
+	const {
+		return SessionStorageType.native;
+	}
+
+	Session create()
+	{
+		auto s = createSessionInstance();
+		m_sessions[s.id] = null;
+		return s;
+	}
+
+	Session open(string id)
+	{
+		auto pv = id in m_sessions;
+		return pv ? createSessionInstance(id) : Session.init;
+	}
+
+	void set(string id, string name, Variant value)
+	@trusted { // Variant
+		m_sessions[id][name] = value;
+		foreach(k, v; m_sessions[id]) logTrace("Csession[%s][%s] = %s", id, k, v);
+	}
+
+	Variant get(string id, string name, lazy Variant defaultVal)
+	@trusted { // Variant
+		assert(id in m_sessions, "session not in store");
+		foreach(k, v; m_sessions[id]) logTrace("Dsession[%s][%s] = %s", id, k, v);
+		if (auto pv = name in m_sessions[id]) {
+			return *pv;
+		} else {
+			return defaultVal;
+		}
+	}
+
+	bool isKeySet(string id, string key)
+	{
+		return (key in m_sessions[id]) !is null;
+	}
+
+	void remove(string id, string key)
+	{
+		m_sessions[id].remove(key);
+	}
+
+	void destroy(string id)
+	{
+		m_sessions.remove(id);
+	}
+
+	int delegate(int delegate(ref string key, ref Variant value) @safe) @safe iterateSession(string id)
+	{
+		assert(id in m_sessions, "session not in store");
+		int iterator(int delegate(ref string key, ref Variant value) @safe del)
+		@safe {
+			foreach( key, ref value; m_sessions[id] )
+				if( auto ret = del(key, value) != 0 )
+					return ret;
+			return 0;
+		}
+		return &iterator;
+	}
+
+	int iterateSession(string id, scope int delegate(string key) @safe del)
+	@trusted { // hash map iteration
+		assert(id in m_sessions, "session not in store");
+		foreach (key; m_sessions[id].byKey)
+			if (auto ret = del(key))
+				return ret;
+		return 0;
+	}
+}

--- a/source/vibe/http/status.d
+++ b/source/vibe/http/status.d
@@ -1,0 +1,194 @@
+/**
+	List of all standard HTTP status codes.
+
+	Copyright: © 2012 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Jan Krüger
+*/
+module vibe.http.status;
+
+/**
+	Definitions of all standard HTTP status codes.
+*/
+enum HTTPStatus {
+	continue_                    = 100,
+	switchingProtocols           = 101,
+	ok                           = 200,
+	created                      = 201,
+	accepted                     = 202,
+	nonAuthoritativeInformation  = 203,
+	noContent                    = 204,
+	resetContent                 = 205,
+	partialContent               = 206,
+	multipleChoices              = 300,
+	movedPermanently             = 301,
+	found                        = 302,
+	seeOther                     = 303,
+	notModified                  = 304,
+	useProxy                     = 305,
+	temporaryRedirect            = 307,
+	badRequest                   = 400,
+	unauthorized                 = 401,
+	paymentRequired              = 402,
+	forbidden                    = 403,
+	notFound                     = 404,
+	methodNotAllowed             = 405,
+	notAcceptable                = 406,
+	proxyAuthenticationRequired  = 407,
+	requestTimeout               = 408,
+	conflict                     = 409,
+	gone                         = 410,
+	lengthRequired               = 411,
+	preconditionFailed           = 412,
+	requestEntityTooLarge        = 413,
+	requestURITooLarge           = 414,
+	unsupportedMediaType         = 415,
+	requestedrangenotsatisfiable = 416,
+	expectationFailed            = 417,
+	tooManyRequests              = 429,
+	unavailableForLegalReasons   = 451,
+	internalServerError          = 500,
+	notImplemented               = 501,
+	badGateway                   = 502,
+	serviceUnavailable           = 503,
+	gatewayTimeout               = 504,
+	httpVersionNotSupported      = 505,
+	// WebDAV status codes
+	multiStatus                  = 207,
+	unprocessableEntity          = 422,
+	locked                       = 423,
+	failedDependency             = 424,
+	insufficientStorage          = 507,
+
+	Continue = continue_, /// deprecated
+	SwitchingProtocols = switchingProtocols, /// deprecated
+	OK = ok, /// deprecated
+	Created = created, /// deprecated
+	Accepted = accepted, /// deprecated
+	NonAuthoritativeInformation = nonAuthoritativeInformation, /// deprecated
+	NoContent = noContent, /// deprecated
+	ResetContent = resetContent, /// deprecated
+	PartialContent = partialContent, /// deprecated
+	MultipleChoices = multipleChoices, /// deprecated
+	MovedPermanently = movedPermanently, /// deprecated
+	Found = found, /// deprecated
+	SeeOther = seeOther, /// deprecated
+	NotModified = notModified, /// deprecated
+	UseProxy = useProxy, /// deprecated
+	TemporaryRedirect = temporaryRedirect, /// deprecated
+	BadRequest = badRequest, /// deprecated
+	Unauthorized = unauthorized, /// deprecated
+	PaymentRequired = paymentRequired, /// deprecated
+	Forbidden = forbidden, /// deprecated
+	NotFound = notFound, /// deprecated
+	MethodNotAllowed = methodNotAllowed, /// deprecated
+	NotAcceptable = notAcceptable, /// deprecated
+	ProxyAuthenticationRequired = proxyAuthenticationRequired, /// deprecated
+	RequestTimeout = requestTimeout, /// deprecated
+	Conflict = conflict, /// deprecated
+	Gone = gone, /// deprecated
+	LengthRequired = lengthRequired, /// deprecated
+	PreconditionFailed = preconditionFailed, /// deprecated
+	RequestEntityTooLarge = requestEntityTooLarge, /// deprecated
+	RequestURITooLarge = requestURITooLarge, /// deprecated
+	UnsupportedMediaType = unsupportedMediaType, /// deprecated
+	Requestedrangenotsatisfiable = requestedrangenotsatisfiable, /// deprecated
+	ExpectationFailed = expectationFailed, /// deprecated
+	InternalServerError = internalServerError, /// deprecated
+	NotImplemented = notImplemented, /// deprecated
+	BadGateway = badGateway, /// deprecated
+	ServiceUnavailable = serviceUnavailable, /// deprecated
+	GatewayTimeout = gatewayTimeout, /// deprecated
+	HTTPVersionNotSupported = httpVersionNotSupported, /// deprecated
+}
+
+
+@safe nothrow @nogc pure:
+
+/**
+	Returns a standard text description of the specified HTTP status code.
+*/
+string httpStatusText(int code)
+{
+	switch(code)
+	{
+		default: break;
+		case HTTPStatus.continue_                    : return "Continue";
+		case HTTPStatus.switchingProtocols           : return "Switching Protocols";
+		case HTTPStatus.ok                           : return "OK";
+		case HTTPStatus.created                      : return "Created";
+		case HTTPStatus.accepted                     : return "Accepted";
+		case HTTPStatus.nonAuthoritativeInformation  : return "Non-Authoritative Information";
+		case HTTPStatus.noContent                    : return "No Content";
+		case HTTPStatus.resetContent                 : return "Reset Content";
+		case HTTPStatus.partialContent               : return "Partial Content";
+		case HTTPStatus.multipleChoices              : return "Multiple Choices";
+		case HTTPStatus.movedPermanently             : return "Moved Permanently";
+		case HTTPStatus.found                        : return "Found";
+		case HTTPStatus.seeOther                     : return "See Other";
+		case HTTPStatus.notModified                  : return "Not Modified";
+		case HTTPStatus.useProxy                     : return "Use Proxy";
+		case HTTPStatus.temporaryRedirect            : return "Temporary Redirect";
+		case HTTPStatus.badRequest                   : return "Bad Request";
+		case HTTPStatus.unauthorized                 : return "Unauthorized";
+		case HTTPStatus.paymentRequired              : return "Payment Required";
+		case HTTPStatus.forbidden                    : return "Forbidden";
+		case HTTPStatus.notFound                     : return "Not Found";
+		case HTTPStatus.methodNotAllowed             : return "Method Not Allowed";
+		case HTTPStatus.notAcceptable                : return "Not Acceptable";
+		case HTTPStatus.proxyAuthenticationRequired  : return "Proxy Authentication Required";
+		case HTTPStatus.requestTimeout               : return "Request Time-out";
+		case HTTPStatus.conflict                     : return "Conflict";
+		case HTTPStatus.gone                         : return "Gone";
+		case HTTPStatus.lengthRequired               : return "Length Required";
+		case HTTPStatus.preconditionFailed           : return "Precondition Failed";
+		case HTTPStatus.requestEntityTooLarge        : return "Request Entity Too Large";
+		case HTTPStatus.requestURITooLarge           : return "Request-URI Too Large";
+		case HTTPStatus.unsupportedMediaType         : return "Unsupported Media Type";
+		case HTTPStatus.requestedrangenotsatisfiable : return "Requested range not satisfiable";
+		case HTTPStatus.expectationFailed            : return "Expectation Failed";
+		case HTTPStatus.unavailableForLegalReasons   : return "Unavailable For Legal Reasons";
+		case HTTPStatus.internalServerError          : return "Internal Server Error";
+		case HTTPStatus.notImplemented               : return "Not Implemented";
+		case HTTPStatus.badGateway                   : return "Bad Gateway";
+		case HTTPStatus.serviceUnavailable           : return "Service Unavailable";
+		case HTTPStatus.gatewayTimeout               : return "Gateway Time-out";
+		case HTTPStatus.httpVersionNotSupported      : return "HTTP Version not supported";
+		// WebDAV
+		case HTTPStatus.multiStatus                  : return "Multi-Status";
+		case HTTPStatus.unprocessableEntity          : return "Unprocessable Entity";
+		case HTTPStatus.locked                       : return "Locked";
+		case HTTPStatus.failedDependency             : return "Failed Dependency";
+		case HTTPStatus.insufficientStorage          : return "Insufficient Storage";
+	}
+	if( code >= 600 ) return "Unknown";
+	if( code >= 500 ) return "Unknown server error";
+	if( code >= 400 ) return "Unknown error";
+	if( code >= 300 ) return "Unknown redirection";
+	if( code >= 200 ) return "Unknown success";
+	if( code >= 100 ) return "Unknown information";
+	return "Unknown";
+}
+
+/**
+	Determines if the given status code justifies closing the connection (e.g. evil big request bodies)
+*/
+bool justifiesConnectionClose(int status)
+{
+	switch(status) {
+		default: return false;
+		case HTTPStatus.requestEntityTooLarge:
+		case HTTPStatus.requestURITooLarge:
+		case HTTPStatus.requestTimeout:
+			return true;
+	}
+}
+
+/**
+	Determines if status code is generally successful (>= 200 && < 300)
+*/
+bool isSuccessCode(HTTPStatus status)
+{
+	return status >= 200 && status < 300;
+}
+


### PR DESCRIPTION
We are proposing this PR to port some code from the old vibe.http we think we should mantain and to start introducing some changes.

The PR involves only two, pretty heavy commits to allow for better understanding of the different changes we had to make:

* We ported common files from the old implementation. [common.d](https://github.com/GallaFrancesco/vibe-http/blob/master/source/vibe/http/common.d), [log.d](https://github.com/GallaFrancesco/vibe-http/blob/master/source/vibe/http/log.d), [router.d](https://github.com/GallaFrancesco/vibe-http/blob/master/source/vibe/http/router.d), [session.d](https://github.com/GallaFrancesco/vibe-http/blob/master/source/vibe/http/session.d), [status.d](https://github.com/GallaFrancesco/vibe-http/blob/master/source/vibe/http/status.d) haven't been changed but we employed them to test the new http module.

* We wrote a scoped API to allow `HTTPServerRequest` and `HTTPServerResponse` to be structs with a private pointer instead of classes. The new implementation has `HTTPServerRequest` as a wrapper around `HTTPServerRequestData`, an similarly for `HTTPServerResponse`.

* We turned the `listenHTTP` method into a template, even though it causes incompatibility with the previous API, as shown in [served.d:2207](https://github.com/GallaFrancesco/vibe-http/blob/0a358eb700459ae95085ab91fc5ffd78b42d4943/source/vibe/http/server.d#L2207).

* We wrote `handleHTTP1Connection` and `handleHTTP1Request` in `http1.d` according to the new version of vibe-core. The use of `waitForDataAsync` removes the need for a task to be allocated while waiting.

* To ease the review, we left some parts commented. They either refer to previous code or to the skeleton that was provided to us.

One issue we would like to point out is that we had to modify `vibe-core` and remove the default destructor for TCPConnection.
This requires manually closing the connection if a timeout expires or an error occours, but otherwise the scoped destruction would have prevented its usage inside a closure.

The current implementation of vibe-core results in an error:
```
http1.d(66,14): Error: variable vibe.http.internal.http1.handleHTTP1Request!(TCPConnection).handleHTTP1Request.connection has scoped destruction, cannot build closure 

```
The modified implementation can be found at [https://github.com/GallaFrancesco/vibe-core](https://github.com/GallaFrancesco/vibe-core)