### PR TITLE
Protocol switching for HTTPS using ALPN

### DIFF
--- a/source/vibe/http/internal/http1.d
+++ b/source/vibe/http/internal/http1.d
@@ -167,8 +167,9 @@ private bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnect
 		else {
 			static if (is(InterfaceProxy!ConnectionStream == ConnectionStream))
 				req.clientCertificate = (cast(TLSStream)http_stream).peerCertificate;
-			else
+			else if (is(typeof(http_stream) : TLSStream))
 				req.clientCertificate = http_stream.extract!TLSStreamType.peerCertificate;
+			else
 				assert(false);
 		}
 	}


### PR DESCRIPTION
This should be the last pull of the first milestone, while probably being the smallest, due to the fact that ALPN support for vibe.d was already functioning properly. What I did was to add a simple method `http2Callback` to be set by `settings.tlsContext.alpnCallback`, which is able to detect a `h2` protocol request as stated in the the RFC, section `3.3`. The provided unittest shows a sample server initialization which is able to negotiate successfully the usage of HTTP/2 using a common TLS handshake.

The other change regards `res.clientCertificate` in `http1.d` which doesn't seem to be working properly (I opened an [issue](https://github.com/vibe-d/vibe-http/issues/6) some days ago to notify you of this). 
Due to the dependency of the affected code from `InterfaceProxy` I decided to add a simple check to avoid an extraction of the wrong type using `InterfaceProxy.extract`, which causes an assertion error.