### PR TITLE
Fix so HTTPServerRequest.peer() only returns ip

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1526,7 +1526,7 @@ struct HTTPServerRequestData {
 			if (!m_peer) {
 				version (Have_vibe_core) {} else scope (failure) assert(false);
 				// store the IP address (IPv4 addresses forwarded over IPv6 are stored in IPv4 format)
-				auto peer_address_string = this.clientAddress.toString();
+				auto peer_address_string = this.clientAddress.toAddressString();
 				if (peer_address_string.startsWith("::ffff:") && peer_address_string[7 .. $].indexOf(':') < 0)
 					m_peer = peer_address_string[7 .. $];
 				else m_peer = peer_address_string;


### PR DESCRIPTION
The documentation says peer() should return the ip address, not the ip:port
See http://vibed.org/api/vibe.http.server/HTTPServerRequest.peer