### PR TITLE
Fixed integer decoding error in HPACK

### DIFF
--- a/source/vibe/http/internal/http2/hpack/decoder.d
+++ b/source/vibe/http/internal/http2/hpack/decoder.d
@@ -5,6 +5,7 @@ import vibe.http.internal.http2.hpack.tables;
 import vibe.http.internal.http2.hpack.util;
 
 import vibe.internal.array : AllocAppender;
+import vibe.core.log;
 
 import std.range; // Decoder
 import std.string;
@@ -26,7 +27,7 @@ void decode(I, R, T)(ref I src, ref R dst, ref IndexingTable table,  ref T alloc
 	src = src[1..$];
 
 	if(bbuf & 128) {
-		auto res = decodeInteger(src, bbuf);
+		auto res = decodeInteger(src, bbuf, 7);
 		dst.put(table[res]);
 	} else {
 		HTTP2HeaderTableField hres;
@@ -34,7 +35,7 @@ void decode(I, R, T)(ref I src, ref R dst, ref IndexingTable table,  ref T alloc
 		auto adst = AllocAppender!string(alloc);
 
 		if (bbuf & 64) { // inserted in dynamic table
-			auto idx = bbuf.toInteger(2);
+			size_t idx = bbuf.toInteger(2);
 			if(idx > 0) {  // name == table[index].name, value == literal
 				hres.name = table[idx].name;
 			} else {   // name == literal, value == literal
@@ -47,7 +48,7 @@ void decode(I, R, T)(ref I src, ref R dst, ref IndexingTable table,  ref T alloc
 			hres.neverIndex = false;
 
 		} else if(bbuf & 16) { // NEVER inserted in dynamic table
-			auto idx = bbuf.toInteger(4);
+			size_t idx = decodeInteger(src, bbuf, 4);
 			if(idx > 0) {  // name == table[index].name, value == literal
 				hres.name = table[idx].name;
 			} else {   // name == literal, value == literal
@@ -60,7 +61,7 @@ void decode(I, R, T)(ref I src, ref R dst, ref IndexingTable table,  ref T alloc
 			hres.neverIndex = true;
 
 		} else if(!(bbuf & 32)) { // this occourrence is not inserted in dynamic table
-			auto idx = bbuf.toInteger(4);
+			size_t idx = decodeInteger(src, bbuf, 4);
 			if(idx > 0) {  // name == table[index].name, value == literal
 				hres.name = table[idx].name;
 			} else {   // name == literal, value == literal
@@ -89,10 +90,9 @@ private void setReset(I,R)(ref I dst, ref R buf)
 	buf.reset;
 }
 
-private size_t decodeInteger(I)(ref I src, ubyte bbuf) @safe @nogc
+private size_t decodeInteger(I)(ref I src, ubyte bbuf, uint nbits) @safe @nogc
 {
-	uint nbits = 7;
-	auto res = bbuf.toInteger(1);
+	auto res = bbuf.toInteger(8-nbits);
 
 	if (res < (1 << nbits) - 1) {
 		return res;
@@ -121,6 +121,10 @@ private void decodeLiteral(I,R)(ref I src, ref R dst) @safe
 
 	// take a buffer of remaining octets
 	auto vlen = bbuf.toInteger(1); // value length
+	if(vlen > src.length) {
+		logWarn("Invalid literal decoded");
+		return;
+	}
 	auto buf = src[0..vlen];
 	src = src[vlen..$];
 

--- a/source/vibe/http/internal/http2/hpack/decoder.d
+++ b/source/vibe/http/internal/http2/hpack/decoder.d
@@ -3,6 +3,7 @@ module vibe.http.internal.http2.hpack.decoder;
 import vibe.http.internal.http2.hpack.huffman;
 import vibe.http.internal.http2.hpack.tables;
 import vibe.http.internal.http2.hpack.util;
+import vibe.http.internal.http2.hpack.exception;
 
 import vibe.internal.array : AllocAppender;
 import vibe.core.log;
@@ -121,10 +122,8 @@ private void decodeLiteral(I,R)(ref I src, ref R dst) @safe
 
 	// take a buffer of remaining octets
 	auto vlen = bbuf.toInteger(1); // value length
-	if(vlen > src.length) {
-		logWarn("Invalid literal decoded");
-		return;
-	}
+	enforceHPACK(vlen <= src.length, "Invalid literal decoded");
+
 	auto buf = src[0..vlen];
 	src = src[vlen..$];
 

--- a/source/vibe/http/internal/http2/hpack/exception.d
+++ b/source/vibe/http/internal/http2/hpack/exception.d
@@ -1,8 +1,16 @@
 module vibe.http.internal.http2.hpack.exception;
 
+import std.exception;
+
+T enforceHPACK(T)(T condition, string message = null, string file = __FILE__,
+		typeof(__LINE__) line = __LINE__) @safe
+{
+	return enforce(condition, new HPACKException(message, file, line));
+}
+
 class HPACKException : Exception
 {
-	this(string msg, string file = __FILE__, size_t line = __LINE__) {
+	this(string msg, string file = __FILE__, size_t line = __LINE__) @safe {
 		super(msg, file, line);
 	}
 }

--- a/source/vibe/http/internal/http2/hpack/hpack.d
+++ b/source/vibe/http/internal/http2/hpack/hpack.d
@@ -12,6 +12,7 @@ import std.array; // appender
 import std.algorithm.iteration;
 
 
+/// interface for the HPACK encoder
 void encodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table, bool huffman = true) @safe
 	if(is(I == HTTP2HeaderTableField) || is(ElementType!I : HTTP2HeaderTableField))
 {
@@ -234,6 +235,15 @@ unittest {
 	foreach(i,h; decR2.data.enumerate(0)) {
 		assert(h == expected[i]);
 	}
+
+	/** Cookie header
+	  * cookie: filter=downloading
+	*/
+	auto ckexp = HTTP2HeaderTableField("cookie", "filter=downloading");
+	block = [96, 141, 148, 212, 36, 182, 65, 33, 252, 85, 65, 199, 33, 170, 155];
+	auto ckdec = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(ckdec, table, alloc);
+	assert(ckdec.data.front == ckexp);
 }
 
 

--- a/source/vibe/http/internal/http2/hpack/tables.d
+++ b/source/vibe/http/internal/http2/hpack/tables.d
@@ -1,6 +1,8 @@
 //module vibe.http.internal.hpack.tables;
 module vibe.http.internal.http2.hpack.tables;
 
+import vibe.http.internal.http2.hpack.exception;
+
 import vibe.http.status;
 import vibe.http.common;
 import vibe.core.log;
@@ -67,7 +69,14 @@ struct HTTP2HeaderTableField {
 	static foreach(t; __traits(allMembers, HeaderValue)) {
 		mixin("this(string n, " ~
 				typeof(__traits(getMember, HeaderValue, t)).stringof ~
-				" v) { name = n; value = v; }");
+				" v) @safe { name = n; value = v; }");
+	}
+
+	this(R)(R t) @safe
+		if(is(ElementType!R : string))
+	{
+		assert(t.length == 2, "Invalid range for HTTP2HeaderTableField initializer");
+		this(t[0], t[1]);
 	}
 }
 
@@ -189,6 +198,8 @@ private struct DynamicTable {
 		m_table.capacity = ms;
 	}
 
+	@property void dispose() { m_table.dispose(); }
+
 	// number of elements inside dynamic table
 	@property size_t size() @safe @nogc { return m_size; }
 
@@ -280,6 +291,11 @@ struct IndexingTable {
 		m_dynamic = DynamicTable(ms);
 	}
 
+	~this()
+	{
+		m_dynamic.dispose();
+	}
+
 	@property size_t size() @safe @nogc { return STATIC_TABLE_SIZE + m_dynamic.index + 1; }
 
 	@property bool empty() @safe @nogc { return m_dynamic.size == 0; }
@@ -293,9 +309,9 @@ struct IndexingTable {
 	}
 
 	// element retrieval
-	HTTP2HeaderTableField opIndex(size_t idx) @safe @nogc
+	HTTP2HeaderTableField opIndex(size_t idx) @safe
 	{
-		assert(idx > 0 && idx <= size(), "Invalid table index");
+		enforceHPACK(idx > 0 && idx <= size(), "Invalid HPACK table index");
 
 		if (idx < STATIC_TABLE_SIZE+1) return getStaticTableEntry(idx);
 		else return m_dynamic[m_dynamic.index - (idx - STATIC_TABLE_SIZE) + 1];


### PR DESCRIPTION
The HPACK library failed when an integer which was more than an octet long was feed to the decoder. To fix this, `toInteger` was changed to `decodeInteger` so that the algorithm defined in the [HPACK RFC, section 5.1](https://tools.ietf.org/html/rfc7541#section-5.1) is correctly executed.

An additional test case and some utilities were added to allow for better testing and exception handling.