### PR TITLE
Fix improper closing of HTTP/2 connection on empty streams

### DIFF
--- a/source/vibe/http/internal/http2/multiplexing.d
+++ b/source/vibe/http/internal/http2/multiplexing.d
@@ -32,7 +32,6 @@ import std.container : RedBlackTree;
 /// register a stream on a MUX
 auto registerStream(Mux)(ref Mux multiplexer, const uint sid) @trusted
 {
-	if(sid > 0) logDebug("MUX: Registering stream %d on mux[%s]", sid, multiplexer.stringof);
 	return multiplexer.register(sid);
 }
 


### PR DESCRIPTION
A check on `stream.empty` in `handleHTTP2FrameChain` forced `connection.close()` to be called, while HTTP/2 requires persistent connections which should remain open until specifically notified (usually with a GOAWAY Frame). Because of this it occurred that a connection was closed leaving a HTTP/2 client hanging on new requests.

Removing the unnecessary check solves the issue (see `http2.d:263`). The other changes are simple corrections to log messages used in `http2.d` and `multiplexing.d` (they became a bit messy when using `trace` as a loglevel).