### PR TITLE
Fix various deprecation warnings inside library code

### DIFF
--- a/source/vibe/http/internal/http1.d
+++ b/source/vibe/http/internal/http1.d
@@ -439,7 +439,7 @@ private bool originalHandleRequest(InterfaceProxy!Stream http_stream, TCPConnect
 	// finalize (e.g. for chunked encoding)
 	res.finalize();
 
-	foreach (k, v ; req._files) {
+	foreach (k, v ; req._files.byKeyValue) {
 		if (existsFile(v.tempPath)) {
 			removeFile(v.tempPath);
 			logDebug("Deleted upload tempfile %s", v.tempPath.toString());

--- a/source/vibe/http/internal/http2/hpack/tables.d
+++ b/source/vibe/http/internal/http2/hpack/tables.d
@@ -90,7 +90,7 @@ immutable size_t STATIC_TABLE_SIZE = 61;
   */
 static immutable HTTP2HeaderTableField[STATIC_TABLE_SIZE+1] StaticTable;
 
-static this() {
+shared static this() {
 	StaticTable = [
 		HTTP2HeaderTableField("",""), // 0 index is not allowed
 		HTTP2HeaderTableField(":authority", ""),

--- a/source/vibe/http/internal/http2/http2.d
+++ b/source/vibe/http/internal/http2/http2.d
@@ -937,7 +937,6 @@ unittest {
 
 unittest {
 	import vibe.core.core : runApplication;
-	setLogLevel(LogLevel.debug_);
 
 	void handleRequest (HTTPServerRequest req, HTTPServerResponse res)
 	@safe {

--- a/source/vibe/http/internal/http2/settings.d
+++ b/source/vibe/http/internal/http2/settings.d
@@ -366,7 +366,7 @@ struct HTTP2ServerContext
 	@property ref HTTP2Settings settings() @safe @nogc
 	{
 		assert(!m_settings.isNull);
-		return m_settings;
+		return m_settings.get;
 	}
 
 	@property void settings(ref HTTP2Settings settings) @safe


### PR DESCRIPTION
The following deprecation warnings are fixed:

* Deprecation: function `std.typecons.Nullable!string.Nullable.get_` is deprecated - Implicit conversion with `alias Nullable.get this` will be removed after 2.096. Please use `.get` explicitly

* Deprecation: alias `byKeyValue` this is deprecated - Iterate over `.byKeyValue` instead

* Deprecation: initialization of immutable variable from `static this` is deprecated. Use `shared static this` instead.