### PR TITLE
Avoid excessive heap allocations in HPACK's dynamic table

### DIFF
--- a/source/vibe/http/internal/http2/hpack/tables.d
+++ b/source/vibe/http/internal/http2/hpack/tables.d
@@ -184,7 +184,7 @@ HTTP2SettingValue computeEntrySize(HTTP2HeaderTableField f) @safe
 private struct DynamicTable {
 	private {
 		// default table is 4096 octs. / n. octets of an empty HTTP2HeaderTableField struct (32)
-		FixedRingBuffer!(HTTP2HeaderTableField, DEFAULT_DYNAMIC_TABLE_SIZE/32, false) m_table;
+		FixedRingBuffer!(HTTP2HeaderTableField, DEFAULT_DYNAMIC_TABLE_SIZE/HTTP2HeaderTableField.sizeof, false) m_table;
 
 		// extra table is a circular buffer, initially empty, used when
 		// maxsize > DEFAULT_DYNAMIC_TABLE_SIZE
@@ -208,7 +208,7 @@ private struct DynamicTable {
 		m_maxsize = ms;
 
 		if(ms > DEFAULT_DYNAMIC_TABLE_SIZE) {
-			m_extraTable.capacity = (ms - DEFAULT_DYNAMIC_TABLE_SIZE)/32;
+			m_extraTable.capacity = (ms - DEFAULT_DYNAMIC_TABLE_SIZE)/HTTP2HeaderTableField.sizeof;
 		}
 	}
 

--- a/source/vibe/http/internal/http2/hpack/tables.d
+++ b/source/vibe/http/internal/http2/hpack/tables.d
@@ -216,8 +216,6 @@ private struct DynamicTable {
 
 	@property size_t index() @safe @nogc { return m_index; }
 
-	@property ref auto table() @safe @nogc { return m_table; }
-
 	HTTP2HeaderTableField opIndex(size_t idx) @safe @nogc
 	{
 		size_t totIndex = m_index + m_extraIndex;
@@ -294,8 +292,6 @@ unittest {
 	dt.insert(h);
 	assert(dt.size > 0);
 	assert(dt.index == 1);
-	assert(equal(dt.table[], [h]));
-	assert(dt.table[].front.name == "test");
 	assert(dt[dt.index].name == "test");
 
 	dt.remove();

--- a/source/vibe/http/internal/http2/settings.d
+++ b/source/vibe/http/internal/http2/settings.d
@@ -139,7 +139,7 @@ struct HTTP2Settings {
 
 	// no limit specified in the RFC
 	@http2Setting(0x1, "SETTINGS_HEADER_TABLE_SIZE")
-	HTTP2SettingValue headerTableSize = 4096;
+	HTTP2SettingValue headerTableSize = DEFAULT_DYNAMIC_TABLE_SIZE;
 
 	// TODO {0,1} otherwise CONNECTION_ERROR
 	@http2Setting(0x2, "SETTINGS_ENABLE_PUSH")
@@ -319,7 +319,6 @@ struct HTTP2ServerContext
 	alias m_context this;
 
 	// used to mantain the first request in case of `h2c` protocol switching
-	// TODO find alternative approach
 	ubyte[] resFrame = void;
 
 	this(HTTPServerContext ctx, HTTP2Settings settings) @safe


### PR DESCRIPTION
Two improvements that can help minimizing heap usage by the HPACK module:

### 1: Set table size in octets instead of number of entries

We were using the struct size for the dynamic table, creating a buffer which could hold up to 4096 `HTTP2HeaderTableField` entries. RFC 7540 specifies that the default value for the `SETTINGS_HEADER_TABLE_SIZE` parameter is, instead, 4096 octets. For this reason the initial dynamic table size is now computed as 4096 / (size of an empty `struct HTTP2HeaderTableField`) which is 32 octets. A test case has been added to make sure that this value is respected.

### 2: Avoid calling FixedRingBuffer.capacity
Profiling heap allocations with `buildOptions "profileGC"` and sending a single HTTP/2 request to the webserver, the heaviest heap allocation is performed by the  forced use of `FixedRingBuffer.capacity` in the constructor for the internal `DynamicTable`, called when the main HPACK table for the HTTP/2 server is created.

Since we are using a fixed, default value for the header table size, it seems unnecessary to call `capacity` when most of the time the table size is set to 4096. It makes more sense to allow for two tables which can be used behind a unique interface:

* `m_table` is a statically-allocated table with size of 4096, which gets created on struct DynamicTable initialization
* `m_extraTable` is a dynamically allocated table which gets initialized iff the constructor for DynamicTable is called with a size parameter > 4096. Its size is therefore set to `ms - 4096` and its entries are filled only when `m_table` is full.

Note that most clients (especially browsers) use the default value of 4096 octets when initializing a HTTP/2 connection, in which case the extra table is not initialized and the HPACK `IndexingTable` should not require dynamic allocations at all.
