### PR TITLE
Proxy supports multiple headers with same name

### DIFF
--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -181,7 +181,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 			if ("Content-Length" !in cres.headers && "Transfer-Encoding" !in cres.headers || req.method == HTTPMethod.HEAD) {
 				foreach (key, ref value; cres.headers.byKeyValue)
 					if (icmp2(key, "Connection") != 0)
-						res.headers[key] = value;
+						res.headers.addField(key,value);
 				res.writeVoidBody();
 				return;
 			}
@@ -192,7 +192,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 				// copy all headers that may pass from upstream to client
 				foreach (n, ref v; cres.headers.byKeyValue)
 					if (n !in non_forward_headers_map)
-						res.headers[n] = v;
+						res.headers.addField(n,v);
 
 				if ("Transfer-Encoding" in res.headers) res.headers.remove("Transfer-Encoding");
 				auto content = cres.bodyReader.readAll(1024*1024);
@@ -207,7 +207,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 				if ("Content-Encoding" in res.headers) res.headers.remove("Content-Encoding");
 				foreach (key, ref value; cres.headers.byKeyValue)
 					if (icmp2(key, "Connection") != 0)
-						res.headers[key] = value;
+						res.headers.addField(key,value);
 				auto size = cres.headers["Content-Length"].to!size_t();
 				if (res.isHeadResponse) res.writeVoidBody();
 				else cres.readRawBody((scope InterfaceProxy!InputStream reader) { res.writeRawBody(reader, size); });
@@ -219,7 +219,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 			// copy all headers that may pass from upstream to client
 			foreach (n, ref v; cres.headers.byKeyValue)
 				if (n !in non_forward_headers_map)
-					res.headers[n] = v;
+					res.headers.addField(n,v);
 			if (res.isHeadResponse) res.writeVoidBody();
 			else cres.bodyReader.pipe(res.bodyWriter);
 		}

--- a/tests/vibe.http.proxy.copyHeaders/dub.sdl
+++ b/tests/vibe.http.proxy.copyHeaders/dub.sdl
@@ -1,4 +1,3 @@
 name "tests"
 description "proxy tests"
 dependency "vibe-http" path="../../"
-versions "VibeDefaultMain"

--- a/tests/vibe.http.proxy.copyHeaders/dub.sdl
+++ b/tests/vibe.http.proxy.copyHeaders/dub.sdl
@@ -1,0 +1,4 @@
+name "tests"
+description "proxy tests"
+dependency "vibe-http" path="../../"
+versions "VibeDefaultMain"

--- a/tests/vibe.http.proxy.copyHeaders/source/app.d
+++ b/tests/vibe.http.proxy.copyHeaders/source/app.d
@@ -1,0 +1,54 @@
+import vibe.core.core;
+import vibe.core.log;
+import vibe.http.client;
+import vibe.http.server;
+import vibe.http.proxy;
+import vibe.http.router;
+import vibe.stream.operations : readAllUTF8;
+import std.algorithm : find;
+import std.range.primitives : front;
+import std.socket : AddressFamily;
+import std.stdio;
+
+shared static this()
+{
+	{
+		auto settings = new HTTPServerSettings;
+		settings.port = 80;
+	        settings.bindAddresses = ["::1", "0.0.0.0"];
+
+		immutable serverAddr = listenHTTP(settings, (scope req, scope res) {
+			res.headers.addField("X","Y");
+			res.headers.addField("X","Z");
+			res.writeBody("Hello world.");
+		}).bindAddresses.find!(addr => addr.family == AddressFamily.INET).front;
+	}
+	{
+		auto router = new URLRouter;
+		router.get("/", reverseProxyRequest("0.0.0.0",80));
+		auto settings = new HTTPServerSettings;
+		settings.port = 8080;
+		settings.bindAddresses = ["::1", "0.0.0.0"];
+		listenHTTP(settings, router);
+	}
+
+	runTask({
+		scope (exit) exitEventLoop();
+		try {
+			auto res = requestHTTP("http://0.0.0.0:8080");
+			assert(res.statusCode == HTTPStatus.ok);
+			bool hadY;
+			bool hadZ;
+			foreach(k,v;res.headers.byKeyValue)
+			{
+				if ((k == "X") && (v == "Y")) hadY = true;
+				if ((k == "X") && (v == "Z")) hadZ = true;
+			}
+			assert(hadZ);
+			assert(hadY);
+			assert(res.bodyReader.readAllUTF8 == "Hello world.");
+		} catch (Exception e) assert(false, e.msg);
+		logInfo("All web tests succeeded.");
+	});
+	runApplication();
+}

--- a/tests/vibe.http.proxy.copyHeaders/source/app.d
+++ b/tests/vibe.http.proxy.copyHeaders/source/app.d
@@ -10,7 +10,7 @@ import std.range.primitives : front;
 import std.socket : AddressFamily;
 import std.stdio;
 
-shared static this()
+void main()
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 0;
@@ -26,22 +26,15 @@ shared static this()
 	router.get("/", reverseProxyRequest(serverAddr.toAddressString,serverAddr.port));
 	immutable proxyAddr = listenHTTP(settings, router).bindAddresses.find!(addr => addr.family == AddressFamily.INET).front;
 
-	runTask({
-		scope (exit) exitEventLoop();
-		try {
-			auto res = requestHTTP("http://" ~ proxyAddr.toString);
-			assert(res.statusCode == HTTPStatus.ok);
-			bool hadY;
-			bool hadZ;
-			foreach(k,v;res.headers.byKeyValue)
-			{
-				if ((k == "X") && (v == "Y")) hadY = true;
-				if ((k == "X") && (v == "Z")) hadZ = true;
-			}
-			assert(hadZ);
-			assert(hadY);
-			assert(res.bodyReader.readAllUTF8 == "Hello world.");
-		} catch (Exception e) assert(false, e.msg);
-	});
-	runApplication();
+	auto res = requestHTTP("http://" ~ proxyAddr.toString);
+	assert(res.statusCode == HTTPStatus.ok);
+	bool hadY;
+	bool hadZ;
+	foreach (k, v; res.headers.byKeyValue) {
+		if ((k == "X") && (v == "Y")) hadY = true;
+		if ((k == "X") && (v == "Z")) hadZ = true;
+	}
+	assert(hadZ);
+	assert(hadY);
+	assert(res.bodyReader.readAllUTF8 == "Hello world.");
 }


### PR DESCRIPTION
Failing test demonstrates that multiple headers with same name don't pass through proxy.
Test passes with modifications to proxy.d