### PR TITLE
mitigate memory leak in http client due to unreliable lazy parameter spec

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -565,7 +565,7 @@ final class HTTPClient {
 		{
 			try responder(res);
 			catch (Exception e) {
-				logDebug("Error while handling response: %s", e.toString().sanitize());
+				logDebug("Error while handling response: %s", () => e.toString().sanitize());
 				user_exception = e;
 			}
 			if (res.statusCode < 200) {


### PR DESCRIPTION
When http client is used heavily with high probability of failed requests (400 response from the remote server is sufficient in my case), VIRT/RSS of the vibe-d server process raises infinitely under dmd 2.083, even when loglevel is not debug. Two things are obvious from Heaptrack traces:

1. logDebug's second parameter is not lazified.
2. e.toString().sanitize() leaks memory.