### PR TITLE
Allow access to const cookies from const HTTPServerRequest

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -982,7 +982,7 @@ final class HTTPServerRequest : HTTPRequest {
 		the request URI. By default, the first cookie will be returned, which is
 		the or one of the cookies with the closest path match.
 	*/
-	@property ref CookieValueMap cookies()
+	@property ref inout CookieValueMap cookies()
 	@safe return {
 		if (m_cookies.isNull) {
 			m_cookies = CookieValueMap.init;

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -982,13 +982,18 @@ final class HTTPServerRequest : HTTPRequest {
 		the request URI. By default, the first cookie will be returned, which is
 		the or one of the cookies with the closest path match.
 	*/
-	@property ref inout CookieValueMap cookies()
+	@property ref CookieValueMap cookies()
 	@safe return {
 		if (m_cookies.isNull) {
 			m_cookies = CookieValueMap.init;
 			if (auto pv = "cookie" in headers)
 				parseCookies(*pv, m_cookies.get);
 		}
+		return m_cookies.get;
+	}
+
+	@property ref const CookieValueMap cookies() cons
+	{
 		return m_cookies.get;
 	}
 

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -992,7 +992,7 @@ final class HTTPServerRequest : HTTPRequest {
 		return m_cookies.get;
 	}
 
-	@property ref const CookieValueMap cookies()
+	@property ref const(CookieValueMap) cookies() const
 	{
 		return m_cookies.get;
 	}

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -992,7 +992,7 @@ final class HTTPServerRequest : HTTPRequest {
 		return m_cookies.get;
 	}
 
-	@property ref const CookieValueMap cookies() cons
+	@property ref const CookieValueMap cookies() const
 	{
 		return m_cookies.get;
 	}

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -992,7 +992,7 @@ final class HTTPServerRequest : HTTPRequest {
 		return m_cookies.get;
 	}
 
-	@property ref const CookieValueMap cookies() const
+	@property ref const CookieValueMap cookies()
 	{
 		return m_cookies.get;
 	}


### PR DESCRIPTION
WebSocket.request() returns a const HTTPServerRequest. Which has a cookies property. We need a const version of cookies to allow it to be read.