### PR TITLE
Cookies: adds SameSite=None option

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -733,6 +733,7 @@ final class Cookie {
 	enum SameSite {
 		default_,
 		lax,
+		none,
 		strict,
 	}
 
@@ -845,6 +846,7 @@ final class Cookie {
 			case default_: break;
 			case lax: dst.put("; SameSite=Lax"); break;
 			case strict: dst.put("; SameSite=Strict"); break;
+			case none: dst.put("; SameSite=None"); break;
 		}
 	}
 


### PR DESCRIPTION
Was added to the standard in ~2020,
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie:

None - Means that the browser sends the cookie with both cross-site and same-site requests