### PR TITLE
HTTP connection handler call: peerAddress added to the error message

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1897,7 +1897,7 @@ private HTTPListener listenHTTPPlain(HTTPServerSettings settings, HTTPServerRequ
 			auto ret = listenTCP(listen_info.bindPort, (TCPConnection conn) nothrow @safe {
 					try handleHTTPConnection(conn, listen_info);
 					catch (Exception e) {
-						logError("HTTP connection handler has thrown: %s", e.msg);
+						logError("HTTP connection handler has thrown at the peer %s: %s", conn.peerAddress, e.msg);
 						debug logDebug("Full error: %s", () @trusted { return e.toString().sanitize(); } ());
 						try conn.close();
 						catch (Exception e) logError("Failed to close connection: %s", e.msg);


### PR DESCRIPTION
At the moment we don't see who is creating corrupted connections. I.e., if we try to run corrupted connection to the HTTPS port:
```
> telnet localhost 8351
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
dsf
Connection closed by foreign host.
```

Maximum detaled log will contain any info but not IP addresses:
```
[main(oway) dbg] Accept TLS connection: server
[main(oway) dbg] OpenSSL error at ../ssl/record/methods/tlsany_meth.c:80: error:0A00010B:SSL routines::wrong version number (-)
[main(oway) ERR] HTTP connection handler has thrown: Accepting SSL tunnel: error:0A00010B:SSL routines::wrong version number (167772427)
[main(oway) dbg] Full error: object.Exception@../../../.dub/packages/vibe-stream/1.1.0/vibe-stream/tls/vibe/stream/openssl.d(677): Accepting SSL tunnel: error:0A00010B:SSL routines::wrong version number (167772427)
[main(oway) dbg] ----------------
[main(oway) dbg] ??:? [0x556710f6a16e]
[...]
```
Proposed PR modifies LogError-level line to:
```
[main(o2we) ERR] HTTP connection handler has thrown at the peer 127.0.0.1:38352: Accepting SSL tunnel: error:0A00010B:SSL routines::wrong version number (167772427)
```