### PR TITLE
Avoid GC leaking the end callback stream.

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -1268,6 +1268,7 @@ final class HTTPClientResponse : HTTPResponse {
 		auto cli = m_client;
 		m_client = null;
 		cli.m_responding = false;
+		destroy(m_bodyReader);
 		destroy(m_endCallback);
 		destroy(m_zlibInputStream);
 		destroy(m_chunkedInputStream);


### PR DESCRIPTION
The end callback stream is stored in the m_bodyReader InputStreamProxy, so that needs to be cleaned up explicitly, too.