### PR TITLE
Only query the remote address for incoming HTTP connections at the beginning

### DIFF
--- a/source/vibe/http/internal/http2/exchange.d
+++ b/source/vibe/http/internal/http2/exchange.d
@@ -124,7 +124,8 @@ unittest {
 	import std.experimental.allocator.mallocator;
 	HTTP2Settings settings;
 	HTTPServerContext ctx;
-	auto context = new HTTP2ServerContext(ctx, settings);
+	NetworkAddress raddr;
+	auto context = new HTTP2ServerContext(ctx, settings, raddr);
 	auto table = IndexingTable(settings.headerTableSize);
 	scope alloc = new RegionListAllocator!(shared(Mallocator), false)(1024, Mallocator.instance);
 
@@ -167,7 +168,7 @@ bool handleHTTP2Request(UStream)(ref HTTP2ConnectionStream!UStream stream,
 	auto req = () @trusted { return alloc.make!HTTPServerRequest(reqtime, listen_info.bindPort); } ();
 	scope (exit) () @trusted { alloc.dispose(req); } ();
 	// store the IP address
-	req.clientAddress = tcp_connection.remoteAddress;
+	req.clientAddress = h2context.remoteAddress;
 
 	if (!listen_info.hasVirtualHosts) {
 		logWarn("Didn't find a HTTP listening context for incoming connection. Dropping.");

--- a/source/vibe/http/internal/http2/settings.d
+++ b/source/vibe/http/internal/http2/settings.d
@@ -313,7 +313,7 @@ final class HTTP2ServerContext
 		FreeListRef!HTTP2Multiplexer m_multiplexer;
 		bool m_initializedT = false;
 		bool m_initializedM = false;
-
+		NetworkAddress m_remoteAddress;
 	}
 
 	alias m_context this;
@@ -321,16 +321,19 @@ final class HTTP2ServerContext
 	// used to mantain the first request in case of `h2c` protocol switching
 	ubyte[] resFrame = void;
 
-	this(HTTPServerContext ctx, HTTP2Settings settings) @safe
-	{
+	this(HTTPServerContext ctx, HTTP2Settings settings, ref NetworkAddress remote_address)
+	@safe {
 		m_context = ctx;
 		m_settings = settings;
+		m_remoteAddress = remote_address;
 	}
 
 	this(HTTPServerContext ctx) @safe
 	{
 		m_context = ctx;
 	}
+
+	@property ref const(NetworkAddress) remoteAddress() const @safe { return m_remoteAddress; }
 
 	@property auto ref table() @safe { return m_table.get; }
 


### PR DESCRIPTION
Fixes possible errors when attempting to query the address on an already closed connection and avoids some computational overhead.