### PR TITLE
Websockets : add maximum packet length and handle fragmented messages

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -263,6 +263,14 @@ class HTTPClientSettings {
 	*/
 	void delegate(TLSContext ctx) @safe nothrow tlsContextSetup;
 
+	/** Maximum payload size to accept in websocket messages
+	 */
+	ulong webSocketPayloadMaxLength = 10_000_000;
+
+	/** A payload size for fragmentation of web socket messages, set to 0 to prevent fragmentation
+	 */
+	ulong webSocketFragmentSize = 0;
+
 	/**
 		TLS Peer name override.
 

--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -265,11 +265,11 @@ class HTTPClientSettings {
 
 	/** Maximum payload size to accept in websocket messages
 	 */
-	ulong webSocketPayloadMaxLength = 10_000_000;
+	size_t webSocketPayloadMaxLength = 10_000_000;
 
 	/** A payload size for fragmentation of web socket messages, set to 0 to prevent fragmentation
 	 */
-	ulong webSocketFragmentSize = 0;
+	size_t webSocketFragmentSize = 0;
 
 	/**
 		TLS Peer name override.

--- a/source/vibe/http/internal/http2/server.d
+++ b/source/vibe/http/internal/http2/server.d
@@ -931,7 +931,7 @@ unittest {
 	// empty handler, just to test if protocol switching works
 	void handleReq(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	@safe {
-		if (req.path == "/")
+		if (req.requestPath.toString == "/")
 			res.writeBody("Hello, World! This response is sent through HTTP/2");
 	}
 
@@ -948,7 +948,7 @@ unittest {
 
 	void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	@safe {
-		if (req.path == "/")
+		if (req.requestPath.toString == "/")
 			res.writeBody("Hello, World! This response is sent through HTTP/2\n");
 	}
 

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -745,6 +745,14 @@ final class HTTPServerSettings {
 		The default value is 60 seconds; set to Duration.zero to disable pings.
 	*/
 	Duration webSocketPingInterval = 60.seconds;
+	
+	/** Maximum payload size to accept in websocket messages
+	 */
+	ulong webSocketPayloadMaxLength = 10_000_000;
+
+	/** A payload size for fragmentation of web socket messages, set to 0 to prevent fragmentation
+	 */
+	ulong webSocketFragmentSize = 0;
 
 	/** Constructs a new settings object with default values.
 	*/

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -748,11 +748,11 @@ final class HTTPServerSettings {
 	
 	/** Maximum payload size to accept in websocket messages
 	 */
-	ulong webSocketPayloadMaxLength = 10_000_000;
+	size_t webSocketPayloadMaxLength = 10_000_000;
 
 	/** A payload size for fragmentation of web socket messages, set to 0 to prevent fragmentation
 	 */
-	ulong webSocketFragmentSize = 0;
+	size_t webSocketFragmentSize = 0;
 
 	/** Constructs a new settings object with default values.
 	*/

--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -888,7 +888,6 @@ scope:
 						break loop;
 					case FrameOpcode.continuation:
 						throw new WebSocketException("unexpected continuation frame");
-						break;
 					case FrameOpcode.text:
 					case FrameOpcode.binary:
 						m_readMutex.performLocked!({

--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -530,8 +530,8 @@ final class WebSocket {
 		/// The entropy generator to use
 		/// If not null, it means this is a server socket.
 		RandomNumberStream m_rng;
-		ulong m_payloadMaxLength;
-		ulong m_fragmentSize;
+		size_t m_payloadMaxLength;
+		size_t m_fragmentSize;
 	}
 
 scope:
@@ -671,7 +671,7 @@ scope:
 	void send(scope const(char)[] data)
 	{
 		send(
-			(scope message)
+			(scope message) @safe
 			{
 				auto frameSize = m_fragmentSize ? m_fragmentSize : data.length;
 				for(size_t offset = 0; offset < data.length; offset += frameSize)
@@ -700,7 +700,7 @@ scope:
 	void send(in ubyte[] data)
 	{
 		send(
-			(scope message)
+			(scope message) @safe
 			{
 				auto frameSize = m_fragmentSize ? m_fragmentSize : data.length;
 				for(size_t offset = 0; offset < data.length; offset += frameSize)
@@ -1022,11 +1022,11 @@ final class IncomingWebSocketMessage : InputStream {
 		RandomNumberStream m_rng;
 		Stream m_conn;
 		Frame m_currentFrame;
-		ulong m_payloadMaxLength;
-		ulong m_nread;
+		size_t m_payloadMaxLength;
+		size_t m_nread;
 	}
 
-	private this(Stream conn, RandomNumberStream rng, ulong payloadMaxLength)
+	private this(Stream conn, RandomNumberStream rng, size_t payloadMaxLength)
 	{
 		assert(conn !is null);
 		m_conn = conn;
@@ -1194,7 +1194,7 @@ private struct Frame {
 		}
 	}
 
-	static Frame readFrame(InputStream stream,ulong payloadMaxLength)
+	static Frame readFrame(InputStream stream,size_t payloadMaxLength)
 	{
 		Frame frame;
 		ubyte[8] data;

--- a/tests/vibe.http.websocket.fragments/dub.sdl
+++ b/tests/vibe.http.websocket.fragments/dub.sdl
@@ -1,3 +1,3 @@
-name "websocket"
+name "websocket_fragments"
 dependency "vibe-http" path="../../"
 versions "VibeDefaultMain"

--- a/tests/vibe.http.websocket.fragments/source/app.d
+++ b/tests/vibe.http.websocket.fragments/source/app.d
@@ -1,0 +1,60 @@
+import vibe.core.core;
+import vibe.core.log;
+import vibe.inet.url;
+import vibe.http.server;
+import vibe.http.websockets;
+import vibe.http.client;
+
+shared static this()
+{
+	//test fragments
+	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	settings.webSocketPayloadMaxLength = 10;
+	settings.webSocketFragmentSize = 4;
+	immutable serverAddr = listenHTTP(settings, handleWebSockets((scope ws) {
+		assert(ws.connected);
+		assert(ws.receiveText() == "12");
+		ws.send("ok");
+		assert(ws.receiveText() == "1234");
+		ws.send("ok");
+		assert(ws.receiveText() == "123456");
+		ws.send("ok");
+		assert(ws.receiveText() == "12345678");
+		ws.send("ok");
+		assert(ws.receiveText() == "123456789");
+		ws.send("ok");
+		try{
+			ws.receiveText();	//at this point the connection should close
+			assert(false);
+		}catch(Exception e)
+		{
+		}
+		ws.close();
+	})).bindAddresses[0];
+
+	runTask({
+		scope(exit) exitEventLoop(true);
+		auto settings = new HTTPClientSettings;
+		settings.webSocketFragmentSize = 4;
+		try connectWebSocket(URL("http://" ~ serverAddr.toString), (scope ws) {
+			assert(ws.connected);
+			ws.send("12");	//single fragment
+			assert(ws.receiveText() == "ok");
+			ws.send("1234"); //single fragment
+			assert(ws.receiveText() == "ok");
+			ws.send("123456"); //two fragment
+			assert(ws.receiveText() == "ok");
+			ws.send("12345678"); //two fragment
+			assert(ws.receiveText() == "ok");
+			ws.send("123456789"); //three fragment
+			assert(ws.receiveText() == "ok");
+			ws.send("123456780901"); //three fragment - exeeds payload max length
+			assert(!ws.waitForData);
+			ws.close();
+			logInfo("WebSocket fragment test successful");
+		},settings);
+		catch (Exception e) assert(false, e.msg);
+	});
+}

--- a/tests/vibe.http.websocket.packetmaxlength/dub.sdl
+++ b/tests/vibe.http.websocket.packetmaxlength/dub.sdl
@@ -1,3 +1,3 @@
-name "websocket"
+name "websocket_packetmaxlength"
 dependency "vibe-http" path="../../"
 versions "VibeDefaultMain"

--- a/tests/vibe.http.websocket.packetmaxlength/source/app.d
+++ b/tests/vibe.http.websocket.packetmaxlength/source/app.d
@@ -6,14 +6,21 @@ import vibe.http.websockets;
 
 shared static this()
 {
+	//test max payload
 	auto settings = new HTTPServerSettings;
 	settings.port = 0;
 	settings.bindAddresses = ["127.0.0.1"];
+	settings.webSocketPayloadMaxLength = 10;
 	immutable serverAddr = listenHTTP(settings, handleWebSockets((scope ws) {
 		assert(ws.connected); // issue #2104
-		assert(ws.receiveText() == "foo");
-		ws.send("hello");
-		assert(ws.receiveText() == "bar");
+		assert(ws.receiveText() == "1234567890");
+		ws.send("ok");
+		try{
+			ws.receiveText();	//at this point the connection should close
+			assert(false);
+		}catch(Exception e)
+		{
+		}
 		ws.close();
 	})).bindAddresses[0];
 
@@ -22,14 +29,13 @@ shared static this()
 
 		try connectWebSocket(URL("http://" ~ serverAddr.toString), (scope ws) {
 			assert(ws.connected);
-			ws.send("foo");
-			assert(ws.receiveText() == "hello");
-			ws.send("bar");
+			ws.send("1234567890");
+			assert(ws.receiveText() == "ok");
+			ws.send("1234567890a");		//should cause connection to close
 			assert(!ws.waitForData);
 			ws.close();
-			logInfo("WebSocket test successful");
+			logInfo("WebSocket max payload test successful");
 		});
 		catch (Exception e) assert(false, e.msg);
 	});
 }
-

--- a/tests/vibe.http.websocket/source/app.d
+++ b/tests/vibe.http.websocket/source/app.d
@@ -32,3 +32,40 @@ shared static this()
 		catch (Exception e) assert(false, e.msg);
     });
 }
+
+
+shared static this()
+{
+	//test max payload
+	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	settings.webSocketPayloadMaxLength = 10;
+	immutable serverAddr = listenHTTP(settings, handleWebSockets((scope ws) {
+		assert(ws.connected); // issue #2104
+		assert(ws.receiveText() == "1234567890");
+		ws.send("ok");
+		try{
+			ws.receiveText();	//at this point the connection should close
+			assert(false);
+		}catch(Exception e)
+		{
+		}
+		ws.close();
+	})).bindAddresses[0];
+
+	runTask({
+		scope(exit) exitEventLoop(true);
+
+		try connectWebSocket(URL("http://" ~ serverAddr.toString), (scope ws) {
+			assert(ws.connected);
+			ws.send("1234567890");
+			assert(ws.receiveText() == "ok");
+			ws.send("1234567890a");		//should cause connection to close
+			assert(!ws.waitForData);
+			ws.close();
+			logInfo("WebSocket test successful");
+		});
+		catch (Exception e) assert(false, e.msg);
+    });
+}


### PR DESCRIPTION
**This PR implements a maximum payload limit in Websocket messages.**
There was a TODO in the comments about this to prevent a DOS attack by sending a really large message.
I set the default value of websocketPacketMaxLength to 10M. This should be set to something reasonable by default to have DOS safety by default.

**This PR allows fragmented websocket messages.**
Some browsers seem to send messages in multiple fragments as described in the web sockets RFC. There was another TODO about this and partial implementation.
Fragmenting in the client is mainly for testing the server.