### PR TITLE
Prevent send when m_conn is null.

### DIFF
--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -724,7 +724,7 @@ scope:
 	void send(scope void delegate(scope OutgoingWebSocketMessage) @safe sender, FrameOpcode frameOpcode)
 	{
 		m_writeMutex.performLocked!({
-			enforce!WebSocketException(!m_sentCloseFrame, "WebSocket connection already actively closed.");
+			enforce!WebSocketException(connected, "WebSocket not connected.");
 			/*scope*/auto message = new OutgoingWebSocketMessage(m_conn, frameOpcode, m_rng);
 			scope(exit) message.finalize();
 			sender(message);


### PR DESCRIPTION
It is possible to have m_conn = null without a connection being actively closed. 
I had a crash where an outgoing message was being sent from sendPing when m_conn = null. 
This fix will cause an exception instead of a crash on the assertion failure in OutgoingMessage constructor.