### PR TITLE
Adds HTTPClientRequest.setCookie method

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -976,7 +976,11 @@ struct CookieValueMap {
 	}
 
 	void add(string name, string value, .Cookie.Encoding encoding = .Cookie.Encoding.url){
-		m_entries ~= Cookie(name, value, encoding);
+		add(Cookie(name, value, encoding));
+	}
+
+	void add(Cookie cookie){
+		m_entries ~= cookie;
 	}
 
 	void opIndexAssign(string value, string name)

--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -1105,3 +1105,38 @@ package void freeRequestAllocator(Allocator)(ref Allocator alloc)
 {
 	destroy(alloc);
 }
+
+package void parseCookies(string str, ref CookieValueMap cookies)
+@safe {
+	import std.encoding : sanitize;
+	import std.string : strip;
+	import std.algorithm.searching : findSplit;
+	import std.algorithm.iteration : map, filter, each;
+	import vibe.http.common : Cookie;
+	() @trusted { return str.sanitize; } ()
+		.split(";")
+		.map!(kv => kv.strip.findSplit("="))
+		.filter!(kv => kv[1].length) //ignore illegal cookies
+		.each!(kv => cookies.add(kv[0], kv[2], Cookie.Encoding.raw) );
+}
+
+unittest
+{
+  auto cvm = CookieValueMap();
+  parseCookies("foo=bar;; baz=zinga; öö=üü   ;   møøse=was=sacked;    onlyval1; =onlyval2; onlykey=", cvm);
+  assert(cvm["foo"] == "bar");
+  assert(cvm["baz"] == "zinga");
+  assert(cvm["öö"] == "üü");
+  assert(cvm["møøse"] == "was=sacked");
+  assert( "onlyval1" ! in cvm); //illegal cookie gets ignored
+  assert(cvm["onlykey"] == "");
+  assert(cvm[""] == "onlyval2");
+  assert(cvm.length() == 6);
+  cvm = CookieValueMap();
+  parseCookies("", cvm);
+  assert(cvm.length() == 0);
+  cvm = CookieValueMap();
+  parseCookies(";;=", cvm);
+  assert(cvm.length() == 1);
+  assert(cvm[""] == "");
+}

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1969,41 +1969,6 @@ private HTTPListener listenHTTPPlain(HTTPServerSettings settings, HTTPServerRequ
 	return HTTPListener(vid);
 }
 
-private void parseCookies(string str, ref CookieValueMap cookies)
-@safe {
-	import std.encoding : sanitize;
-	import std.string : strip;
-	import std.algorithm.searching : findSplit;
-	import std.algorithm.iteration : map, filter, each;
-	import vibe.http.common : Cookie;
-	() @trusted { return str.sanitize; } ()
-		.split(";")
-		.map!(kv => kv.strip.findSplit("="))
-		.filter!(kv => kv[1].length) //ignore illegal cookies
-		.each!(kv => cookies.add(kv[0], kv[2], Cookie.Encoding.raw) );
-}
-
-unittest
-{
-  auto cvm = CookieValueMap();
-  parseCookies("foo=bar;; baz=zinga; öö=üü   ;   møøse=was=sacked;    onlyval1; =onlyval2; onlykey=", cvm);
-  assert(cvm["foo"] == "bar");
-  assert(cvm["baz"] == "zinga");
-  assert(cvm["öö"] == "üü");
-  assert(cvm["møøse"] == "was=sacked");
-  assert( "onlyval1" ! in cvm); //illegal cookie gets ignored
-  assert(cvm["onlykey"] == "");
-  assert(cvm[""] == "onlyval2");
-  assert(cvm.length() == 6);
-  cvm = CookieValueMap();
-  parseCookies("", cvm);
-  assert(cvm.length() == 0);
-  cvm = CookieValueMap();
-  parseCookies(";;=", cvm);
-  assert(cvm.length() == 1);
-  assert(cvm[""] == "");
-}
-
 shared static this()
 {
 	version (VibeNoDefaultArgs) {}

--- a/tests/vibe.http.client.client-cookies/dub.sdl
+++ b/tests/vibe.http.client.client-cookies/dub.sdl
@@ -1,0 +1,2 @@
+name "client-cookies"
+dependency "vibe-http" path="../../"

--- a/tests/vibe.http.client.client-cookies/source/app.d
+++ b/tests/vibe.http.client.client-cookies/source/app.d
@@ -1,0 +1,35 @@
+/++ dub.sdl:
+	dependency "vibe-d" path=".."
++/
+import vibe.core.core;
+import vibe.http.client;
+import vibe.http.server;
+import vibe.core.log;
+
+void main()
+{
+	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	auto l = listenHTTP(settings, (req, res) {
+		assert(req.cookies["clientCookie1"] == "test value");
+		assert(req.cookies["clientCookie2"] == "123");
+		res.writeBody("Hello, World!");
+	});
+
+	auto url = URL("http", "127.0.0.1", l.bindAddresses[0].port, InetPath("/"));
+
+	runTask({
+		try {
+			auto res = requestHTTP(url, (req){
+				req.setCookie("clientCookie2", "123");
+				req.setCookie("clientCookie1", "test value");
+			});
+			assert(res.statusCode == 200, res.toString);
+
+			res.dropBody();
+			exitEventLoop();
+		} catch (Exception e) assert(false, e.msg);
+	});
+	runApplication();
+}


### PR DESCRIPTION
Encountered to the fact that there is no method for setting cookies on the client side

I implemented it in the same manner as it implemented for server side

`parseCookies` was moved to `common` module to make it available in the `client` module