### PR TITLE
fix(server): Add an overload to disembiguate writeBody(null) call

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1343,6 +1343,15 @@ scope:
 		statusCode = status;
 		writeBody(data, content_type);
 	}
+    /// Ditto
+	void writeBody(in typeof(null) data, string content_type = null)
+	@safe {
+        return this.writeBody((ubyte[]).init, content_type);
+	}
+	/// ditto
+	void writeBody(in typeof(null) data, int status, string content_type = null) {
+        return this.writeBody((ubyte[]).init, status, content_type);
+    }
 
 	/** Writes the entire response body as a single string.
 
@@ -2026,3 +2035,13 @@ shared static this()
 
 version (VibeDebugCatchAll) package alias UncaughtException = Throwable;
 else package alias UncaughtException = Exception;
+
+// Because we define a `in ubyte[]` and a `string` version,
+// calling `writeBody(null)` was ambiguous.
+unittest {
+    void noCall (scope HTTPServerResponse res) {
+        res.writeBody(null);
+        res.writeBody(null, 200);
+        res.writeBody(null, 200, null);
+    }
+}


### PR DESCRIPTION
Without this, one will get the following errors:
```
    Building vibe-http 1.0.0+commit.113.ge3ae3d3: building configuration [vibe-http-test-library]
source/vibe/http/server.d(2034,22): Error: `vibe.http.server.HTTPServerResponse.writeBody` called with argument types `(typeof(null))` matches multiple overloads after qualifier conversion:
source/vibe/http/server.d(1320,7):     `vibe.http.server.HTTPServerResponse.writeBody(in ubyte[] data, string content_type = null)`
and:
source/vibe/http/server.d(1359,7):     `vibe.http.server.HTTPServerResponse.writeBody(string data, string content_type = null)`
        res.writeBody(null);
                     ^
source/vibe/http/server.d(2035,22): Error: `vibe.http.server.HTTPServerResponse.writeBody` called with argument types `(typeof(null), int)` matches multiple overloads after qualifier conversion:
source/vibe/http/server.d(1328,7):     `vibe.http.server.HTTPServerResponse.writeBody(in ubyte[] data, int status, string content_type = null)`
and:
source/vibe/http/server.d(1366,7):     `vibe.http.server.HTTPServerResponse.writeBody(string data, int status, string content_type = null)`
        res.writeBody(null, 200);
                     ^
source/vibe/http/server.d(2036,22): Error: `vibe.http.server.HTTPServerResponse.writeBody` called with argument types `(typeof(null), int, typeof(null))` matches multiple overloads after qualifier conversion:
source/vibe/http/server.d(1328,7):     `vibe.http.server.HTTPServerResponse.writeBody(in ubyte[] data, int status, string content_type = null)`
and:
source/vibe/http/server.d(1366,7):     `vibe.http.server.HTTPServerResponse.writeBody(string data, int status, string content_type = null)`
        res.writeBody(null, 200, null);
                     ^
Error /home/mlang/dlang/ldc-1.41.0/bin/ldc2 failed with exit code 1.
```