### PR TITLE
fix(server): Enforce writeBody respect the spec with status = No Content

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1317,18 +1317,23 @@ scope:
 
 		See_Also: `HTTPStatusCode`
 	*/
-	void writeBody(in ubyte[] data, string content_type = null)
+	void writeBody(in ubyte[] data, int status, string content_type = null)
 	@safe {
-		if (content_type.length) headers["Content-Type"] = content_type;
-		else if ("Content-Type" !in headers) headers["Content-Type"] = "application/octet-stream";
-		headers["Content-Length"] = formatAlloc(m_requestAlloc, "%d", data.length);
+        this.statusCode = status;
+        if (content_type.length) headers["Content-Type"] = content_type;
+        else if ("Content-Type" !in headers) headers["Content-Type"] = "application/octet-stream";
+		// It is forbidden by spec to set `Content-Length` on a 204 / No Content response
+		// https://datatracker.ietf.org/doc/html/rfc2616#section-4.4
+		if (status != HTTPStatus.noContent)
+			headers["Content-Length"] = formatAlloc(m_requestAlloc, "%d", data.length);
+		else
+			enforce(!data.length, "Cannot call HTTPServerResponse.writeBody with non-empty 'data' and 'status' = 'No Content'");
 		bodyWriter.write(data);
 	}
 	/// ditto
-	void writeBody(in ubyte[] data, int status, string content_type = null)
+	void writeBody(in ubyte[] data, string content_type = null)
 	@safe {
-		statusCode = status;
-		writeBody(data, content_type);
+		writeBody(data, this.statusCode, content_type);
 	}
 	/// ditto
 	void writeBody(scope InputStream data, string content_type = null)

--- a/tests/vibe.http.server.no-content-writebody/dub.sdl
+++ b/tests/vibe.http.server.no-content-writebody/dub.sdl
@@ -1,0 +1,3 @@
+name "tests"
+description "HTTP 204 writeBody should not emit Content-Length"
+dependency "vibe-http" path="../../"

--- a/tests/vibe.http.server.no-content-writebody/source/app.d
+++ b/tests/vibe.http.server.no-content-writebody/source/app.d
@@ -1,0 +1,42 @@
+import vibe.core.core : exitEventLoop, runApplication, runTask;
+import vibe.http.client : requestHTTP;
+import vibe.http.server;
+import vibe.stream.operations : readAllUTF8;
+
+import std.conv : to;
+
+void main()
+{
+	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+
+	auto listener = listenHTTP(settings, &handler);
+	scope (exit) listener.stopListening();
+
+	runTask({
+		scope (exit) exitEventLoop();
+
+		try {
+			requestHTTP("http://127.0.0.1:" ~ listener.bindAddresses[0].port.to!string,
+				(scope request) {
+					request.headers["Connection"] = "close";
+				},
+				(scope response) {
+					assert(response.statusCode == HTTPStatus.noContent, response.toString());
+					assert("Content-Length" !in response.headers, "204 response must not include Content-Length");
+					assert(response.bodyReader.readAllUTF8() == "", "204 response must not include a body");
+				}
+			);
+		} catch (Exception e) {
+			assert(false, e.msg);
+		}
+	});
+
+	runApplication();
+}
+
+void handler(scope HTTPServerRequest req, scope HTTPServerResponse res)
+{
+	res.writeBody("", HTTPStatus.noContent);
+}


### PR DESCRIPTION
This comes from my trying to fix an issue with vibe.web.rest. I realized that there was no "good" way to do it, as `writeVoidBody` doesn't accept setting the `HTTPStatus` (might do that later) and `writeBody` didn't respect the spec. It was easier to fix `writeBody`.