### PR TITLE
Refactor proxy tunneling to use tunnelBidirectional

### DIFF
--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -7,7 +7,6 @@
 */
 module vibe.http.proxy;
 
-import vibe.core.core : runTask;
 import vibe.core.log;
 import vibe.http.client;
 import vibe.http.server;
@@ -17,6 +16,89 @@ import vibe.internal.interfaceproxy : InterfaceProxy;
 
 import std.conv;
 import std.exception;
+
+
+/*
+	Bidirectional tunnel between two stream-like endpoints (CONNECT body or
+	protocol upgrade such as WebSocket).
+
+	Two fibers, one per direction.  Each waits for data with a timeout and
+	checks a shared `done` flag.  Uses `waitForDataEx` to distinguish
+	timeout from EOF.
+*/
+private void tunnelBidirectional(A, B)(A a, B b) @safe
+{
+	import vibe.core.core : runTask;
+
+	logInfo("tunnelBidirectional started");
+
+	auto finished = new bool;
+
+	static void pumpAToB(A src, B dst, bool *finished) nothrow {
+		try pump(src, dst, finished);
+		catch (Exception e) {
+			logDebug("Proxy tunnel: forward ended: %s", e.msg);
+		}
+		*finished = true;
+	}
+
+	auto t = runTask(&pumpAToB, a, b, finished);
+
+	try pump(b, a, finished);
+	catch (Exception e) logDebug("Proxy tunnel: forward ended: %s", e.msg);
+
+	*finished = true;
+	try t.join();
+	catch (Exception e) logDebug("Proxy tunnel: join failed: %s", e.msg);
+
+	logInfo("tunnelBidirectional finished");
+}
+
+/*
+	Single-direction pump.  Waits for data with a timeout so it can
+	periodically observe the shared `done` flag.  Uses `waitForDataEx`
+	to distinguish timeout from EOF.
+*/
+private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
+{
+	import core.time : seconds;
+	import std.algorithm : min;
+	import vibe.stream.wrapper : ConnectionProxyStream;
+
+	enum checkInterval = 1.seconds;
+	auto buf = new ubyte[64*1024];
+
+	while (!*finished)
+	{
+		WaitForDataStatus status;
+
+		static if (__traits(hasMember, Src, "waitForDataEx"))
+			status = src.waitForDataEx(checkInterval);
+		else static if (is(Src : ConnectionStream))
+		{
+			auto cps = cast(ConnectionProxyStream)src;
+			assert(cps, "Tunnel requires a ConnectionProxyStream");
+			status = cps.waitForDataEx(checkInterval);
+		}
+		else
+			static assert(false, "Tunnel source must support waitForDataEx");
+
+		final switch (status)
+		{
+		case WaitForDataStatus.dataAvailable:
+			auto chunk = min(src.leastSize, buf.length);
+			if (chunk == 0) return;
+			src.read(buf[0 .. chunk]);
+			dst.write(buf[0 .. chunk]);
+			break;
+		case WaitForDataStatus.noMoreData:
+			*finished = true;
+			return;
+		case WaitForDataStatus.timeout:
+			break;
+		}
+	}
+}
 
 
 /*
@@ -106,19 +188,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 
 			res.writeVoidBody();
 			auto scon = res.connectProxy();
-			assert (scon);
-
-			runTask(() nothrow {
-				try scon.pipe(ccon);
-				catch (Exception e) {
-					logException(e, "Failed to forward proxy data from server to client");
-					try scon.close();
-					catch (Exception e) logException(e, "Failed to close server connection after error");
-					try ccon.close();
-					catch (Exception e) logException(e, "Failed to close client connection after error");
-				}
-			});
-			ccon.pipe(scon);
+			tunnelBidirectional(scon, ccon);
 			return;
 		}
 
@@ -163,18 +233,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 				auto scon = res.switchProtocol("");
 				auto ccon = cres.switchProtocol("");
 
-				runTask(() nothrow {
-					try ccon.pipe(scon);
-					catch (Exception e) {
-						logException(e, "Failed to forward proxy data from client to server");
-						try scon.close();
-						catch (Exception e) logException(e, "Failed to close server connection after error");
-						try ccon.close();
-						catch (Exception e) logException(e, "Failed to close client connection after error");
-					}
-				});
-
-				scon.pipe(ccon);
+				tunnelBidirectional(ccon, scon);
 				return;
 			}
 

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -93,15 +93,15 @@ private void pump(Src, Dst)(string dir,Src src, Dst dst, bool *finished)
 		case WaitForDataStatus.dataAvailable:
 			auto chunk = min(src.leastSize, buf.length);
 			if (chunk == 0) chunk = 1;
-			auto n = src.read(buf[0 .. chunk]);
-			if (n == 0) { *finished = true; return; }
+			try src.read(buf[0 .. chunk]);
+			catch (Exception) { *finished = true; return; }
 			if (iteration < 3)
 			{
-				auto hex = iota(min(n, 16)).map!(i => format("%02x", buf[i])).join(" ");
-				logInfo("pump %s chunk=%d bytes: %s", dir, n, hex);
+				auto hex = iota(min(chunk, 16)).map!(i => format("%02x", buf[i])).join(" ");
+				logInfo("pump %s chunk=%d bytes: %s", dir, chunk, hex);
 				iteration++;
 			}
-			dst.write(buf[0 .. n]);
+			dst.write(buf[0 .. chunk]);
 			break;
 		case WaitForDataStatus.noMoreData:
 			*finished = true;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -93,14 +93,15 @@ private void pump(string dir, Src, Dst)(Src src, Dst dst, bool *finished)
 		case WaitForDataStatus.dataAvailable:
 			auto chunk = min(src.leastSize, buf.length);
 			if (chunk == 0) chunk = 1;
-			src.read(buf[0 .. chunk]);
+			auto n = src.read(buf[0 .. chunk]);
+			if (n == 0) { *finished = true; return; }
 			if (iteration < 3)
 			{
-				auto hex = iota(min(chunk, 16)).map!(i => format("%02x", buf[i])).join(" ");
-				logInfo("pump %s chunk=%d bytes: %s", dir, chunk, hex);
+				auto hex = iota(min(n, 16)).map!(i => format("%02x", buf[i])).join(" ");
+				logInfo("pump %s chunk=%d bytes: %s", dir, n, hex);
 				iteration++;
 			}
-			dst.write(buf[0 .. chunk]);
+			dst.write(buf[0 .. n]);
 			break;
 		case WaitForDataStatus.noMoreData:
 			*finished = true;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -87,7 +87,7 @@ private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
 		{
 		case WaitForDataStatus.dataAvailable:
 			auto chunk = min(src.leastSize, buf.length);
-			if (chunk == 0) return;
+			if (chunk == 0) continue;
 			src.read(buf[0 .. chunk]);
 			dst.write(buf[0 .. chunk]);
 			break;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -64,9 +64,12 @@ private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
 	import core.time : seconds;
 	import std.algorithm : min;
 	import vibe.stream.wrapper : ConnectionProxyStream;
+	import vibe.core.log : logDebug, logInfo;
+	import std.format : format;
 
 	enum checkInterval = 1.seconds;
 	auto buf = new ubyte[64*1024];
+	int iteration;
 
 	while (!*finished)
 	{
@@ -89,6 +92,12 @@ private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
 			auto chunk = min(src.leastSize, buf.length);
 			if (chunk == 0) chunk = 1;
 			src.read(buf[0 .. chunk]);
+			if (iteration < 5)
+			{
+				auto hex = iota(min(chunk, 16)).map!(i => format("%02x", buf[i])).join(" ");
+				logInfo("pump chunk=%d bytes: %s", chunk, hex);
+				iteration++;
+			}
 			dst.write(buf[0 .. chunk]);
 			break;
 		case WaitForDataStatus.noMoreData:
@@ -188,6 +197,8 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 
 			res.writeVoidBody();
 			auto scon = res.connectProxy();
+			assert(scon);
+
 			tunnelBidirectional(scon, ccon);
 			return;
 		}

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -37,17 +37,17 @@ private void tunnelBidirectional(A, B)(A a, B b) @safe
 	auto finished = new bool;
 
 	static void pumpAToB(A src, B dst, bool *finished) nothrow {
-		try pump(src, dst, finished);
+		try pump("up->cli", src, dst, finished);
 		catch (Exception e) {
-			logDebug("Proxy tunnel: forward ended: %s", e.msg);
+			logDebug("Proxy tunnel: up->cli ended: %s", e.msg);
 		}
 		*finished = true;
 	}
 
 	auto t = runTask(&pumpAToB, a, b, finished);
 
-	try pump(b, a, finished);
-	catch (Exception e) logDebug("Proxy tunnel: forward ended: %s", e.msg);
+	try pump("cli->up", b, a, finished);
+	catch (Exception e) logDebug("Proxy tunnel: cli->up ended: %s", e.msg);
 
 	*finished = true;
 	try t.join();
@@ -61,7 +61,7 @@ private void tunnelBidirectional(A, B)(A a, B b) @safe
 	periodically observe the shared `done` flag.  Uses `waitForDataEx`
 	to distinguish timeout from EOF.
 */
-private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
+private void pump(string dir, Src, Dst)(Src src, Dst dst, bool *finished)
 {
 	import core.time : seconds;
 	import std.algorithm : min;
@@ -94,10 +94,10 @@ private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
 			auto chunk = min(src.leastSize, buf.length);
 			if (chunk == 0) chunk = 1;
 			src.read(buf[0 .. chunk]);
-			if (iteration < 5)
+			if (iteration < 3)
 			{
 				auto hex = iota(min(chunk, 16)).map!(i => format("%02x", buf[i])).join(" ");
-				logInfo("pump chunk=%d bytes: %s", chunk, hex);
+				logInfo("pump %s chunk=%d bytes: %s", dir, chunk, hex);
 				iteration++;
 			}
 			dst.write(buf[0 .. chunk]);

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -14,6 +14,7 @@ import vibe.inet.message;
 import vibe.stream.operations;
 import vibe.internal.interfaceproxy : InterfaceProxy;
 import std.range;
+import std.algorithm;
 
 import std.conv;
 import std.exception;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -13,6 +13,7 @@ import vibe.http.server;
 import vibe.inet.message;
 import vibe.stream.operations;
 import vibe.internal.interfaceproxy : InterfaceProxy;
+import std.range;
 
 import std.conv;
 import std.exception;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -87,7 +87,7 @@ private void pump(Src, Dst)(Src src, Dst dst, bool *finished)
 		{
 		case WaitForDataStatus.dataAvailable:
 			auto chunk = min(src.leastSize, buf.length);
-			if (chunk == 0) continue;
+			if (chunk == 0) chunk = 1;
 			src.read(buf[0 .. chunk]);
 			dst.write(buf[0 .. chunk]);
 			break;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -61,7 +61,7 @@ private void tunnelBidirectional(A, B)(A a, B b) @safe
 	periodically observe the shared `done` flag.  Uses `waitForDataEx`
 	to distinguish timeout from EOF.
 */
-private void pump(string dir, Src, Dst)(Src src, Dst dst, bool *finished)
+private void pump(Src, Dst)(string dir,Src src, Dst dst, bool *finished)
 {
 	import core.time : seconds;
 	import std.algorithm : min;


### PR DESCRIPTION
The previous implementation of the bidirectional tunnel relied on one of the fibers being able to close the other fibers socket. This would occasionally cause a fatal assert in vibe-core net.d:768. 
It is impossible to implement this correctly with out exposing waitForDataEx to allow distinguishing between data arriving, end of data and timeout. The timeout allows checking to see if the other pipe has been closed.
This way each fiber closes its own socket naturally, avoiding a race condition that can crash your server.